### PR TITLE
feat: add concurrent model downloads

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -77,6 +77,7 @@ import {
   downloadModel,
   deleteModel,
   cancelDownload,
+  cancelDownloadForFile,
   getModelsDir,
   searchModels,
   getRepoFiles
@@ -1647,7 +1648,10 @@ if (!gotTheLock) {
     ipcMain.handle('huggingface:models:delete', (_event, repo: string, filename: string) => {
       return deleteModel(repo, filename)
     })
-    ipcMain.handle('huggingface:models:cancel', () => {
+    ipcMain.handle('huggingface:models:cancel', (_event, repo?: string, filename?: string) => {
+      if (repo && filename) {
+        return cancelDownloadForFile(repo, filename)
+      }
       cancelDownload()
       return true
     })

--- a/src/main/utils/huggingface.ts
+++ b/src/main/utils/huggingface.ts
@@ -20,7 +20,7 @@ export interface HfModel {
   repo: string
   filename: string
   filepath: string
-  size: number        // bytes
+  size: number // bytes
   downloadedAt: string // ISO date
 }
 
@@ -62,16 +62,27 @@ const writeManifest = (models: HfModel[]): void => {
 
 // ─── Public API ─────────────────────────────────────────
 
-let activeDownloadAbort: AbortController | null = null
+const activeDownloadAborts = new Map<string, AbortController>()
+
+const getDownloadKey = (repo: string, filename: string): string => `${repo}::${filename}`
 
 /**
  * Cancel the current download in progress.
  */
 export const cancelDownload = (): void => {
-  if (activeDownloadAbort) {
-    activeDownloadAbort.abort()
-    activeDownloadAbort = null
+  for (const controller of activeDownloadAborts.values()) {
+    controller.abort()
   }
+  activeDownloadAborts.clear()
+}
+
+export const cancelDownloadForFile = (repo: string, filename: string): boolean => {
+  const key = getDownloadKey(repo, filename)
+  const controller = activeDownloadAborts.get(key)
+  if (!controller) return false
+  controller.abort()
+  activeDownloadAborts.delete(key)
+  return true
 }
 
 /**
@@ -110,6 +121,11 @@ export const downloadModel = async (
   token?: string,
   expectedSize?: number
 ): Promise<string> => {
+  const key = getDownloadKey(repo, filename)
+  if (activeDownloadAborts.has(key)) {
+    throw new Error(`Download already in progress for ${repo}/${filename}`)
+  }
+
   const slug = repoSlug(repo)
   const repoDir = path.join(getHfCacheDir(), slug)
   if (!fs.existsSync(repoDir)) {
@@ -136,34 +152,35 @@ export const downloadModel = async (
     headers['Authorization'] = `Bearer ${token}`
   }
 
-  activeDownloadAbort = new AbortController()
-  const { signal } = activeDownloadAbort
-
-  // Use fetch for streaming download with progress
-  const response = await fetch(downloadUrl, {
-    headers,
-    redirect: 'follow',
-    signal
-  })
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download ${repo}/${filename}: ${response.status} ${response.statusText}`
-    )
-  }
-
-  const contentLength = parseInt(response.headers.get('content-length') ?? '0', 10)
-  const totalBytes = contentLength || expectedSize || 0
-  const reader = response.body?.getReader()
-  if (!reader) {
-    throw new Error('Response body is not readable')
-  }
+  const downloadAbort = new AbortController()
+  activeDownloadAborts.set(key, downloadAbort)
+  const { signal } = downloadAbort
 
   const tmpPath = destPath + '.tmp'
   const writeStream = fs.createWriteStream(tmpPath)
   let downloadedBytes = 0
 
   try {
+    // Use fetch for streaming download with progress
+    const response = await fetch(downloadUrl, {
+      headers,
+      redirect: 'follow',
+      signal
+    })
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download ${repo}/${filename}: ${response.status} ${response.statusText}`
+      )
+    }
+
+    const contentLength = parseInt(response.headers.get('content-length') ?? '0', 10)
+    const totalBytes = contentLength || expectedSize || 0
+    const reader = response.body?.getReader()
+    if (!reader) {
+      throw new Error('Response body is not readable')
+    }
+
     while (true) {
       const { done, value } = await reader.read()
       if (done) break
@@ -182,17 +199,18 @@ export const downloadModel = async (
   } catch (err) {
     writeStream.end()
     // Clean up partial download
-    try { fs.unlinkSync(tmpPath) } catch {}
-    activeDownloadAbort = null
+    try {
+      fs.unlinkSync(tmpPath)
+    } catch {}
     throw err
   } finally {
     writeStream.end()
     await new Promise((resolve) => writeStream.on('finish', resolve))
+    activeDownloadAborts.delete(key)
   }
 
   // Rename tmp to final
   fs.renameSync(tmpPath, destPath)
-  activeDownloadAbort = null
 
   // Update manifest
   const manifest = readManifest()
@@ -260,7 +278,7 @@ export const getModelInfo = (repo: string, filename: string): HfModel | null => 
 // ─── HF API Integration ────────────────────────────────
 
 export interface HfRepoResult {
-  id: string            // e.g. "ggml-org/gemma-3-1b-it-GGUF"
+  id: string // e.g. "ggml-org/gemma-3-1b-it-GGUF"
   author: string
   modelId: string
   downloads: number
@@ -271,17 +289,14 @@ export interface HfRepoResult {
 
 export interface HfFileInfo {
   filename: string
-  size: number          // bytes
+  size: number // bytes
   lfs?: { size: number }
 }
 
 /**
  * Search HF for GGUF model repos.
  */
-export const searchModels = async (
-  query: string,
-  token?: string
-): Promise<HfRepoResult[]> => {
+export const searchModels = async (query: string, token?: string): Promise<HfRepoResult[]> => {
   const params = new URLSearchParams({
     search: query,
     filter: 'gguf',
@@ -313,12 +328,30 @@ export const searchModels = async (
 /**
  * List GGUF files in a HF repo.
  */
-export const getRepoFiles = async (
-  repo: string,
-  token?: string
-): Promise<HfFileInfo[]> => {
+export const getRepoFiles = async (repo: string, token?: string): Promise<HfFileInfo[]> => {
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (token) headers['Authorization'] = `Bearer ${token}`
+
+  const treeResponse = await fetch(
+    `https://huggingface.co/api/models/${repo}/tree/main?recursive=1`,
+    { headers }
+  )
+  if (treeResponse.ok) {
+    const treeData = await treeResponse.json()
+    const treeFiles = (Array.isArray(treeData) ? treeData : [])
+      .filter(
+        (f: any) => f.type === 'file' && typeof f.path === 'string' && f.path.endsWith('.gguf')
+      )
+      .map((f: any) => ({
+        filename: f.path,
+        size: f.lfs?.size ?? f.size ?? 0
+      }))
+      .sort((a: HfFileInfo, b: HfFileInfo) => a.size - b.size)
+
+    if (treeFiles.length > 0) {
+      return treeFiles
+    }
+  }
 
   const response = await fetch(`https://huggingface.co/api/models/${repo}`, { headers })
   if (!response.ok) {
@@ -328,7 +361,6 @@ export const getRepoFiles = async (
   const data = await response.json()
   const siblings = data.siblings ?? []
 
-  // Filter to only GGUF files
   return siblings
     .filter((f: any) => f.rfilename?.endsWith('.gguf'))
     .map((f: any) => ({
@@ -337,4 +369,3 @@ export const getRepoFiles = async (
     }))
     .sort((a: HfFileInfo, b: HfFileInfo) => a.size - b.size)
 }
-

--- a/src/main/utils/huggingface.ts
+++ b/src/main/utils/huggingface.ts
@@ -159,6 +159,7 @@ export const downloadModel = async (
   const tmpPath = destPath + '.tmp'
   const writeStream = fs.createWriteStream(tmpPath)
   let downloadedBytes = 0
+  let downloadSucceeded = false
 
   try {
     // Use fetch for streaming download with progress
@@ -196,16 +197,26 @@ export const downloadModel = async (
         })
       }
     }
+    downloadSucceeded = true
   } catch (err) {
-    writeStream.end()
-    // Clean up partial download
-    try {
-      fs.unlinkSync(tmpPath)
-    } catch {}
     throw err
   } finally {
-    writeStream.end()
-    await new Promise((resolve) => writeStream.on('finish', resolve))
+    if (!writeStream.writableEnded) {
+      writeStream.end()
+    }
+    await new Promise((resolve) => writeStream.on('close', resolve))
+
+    if (!downloadSucceeded && fs.existsSync(tmpPath)) {
+      try {
+        fs.unlinkSync(tmpPath)
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException)?.code
+        if (code !== 'ENOENT') {
+          log.warn(`[huggingface] Failed to remove temp file ${tmpPath}:`, error)
+        }
+      }
+    }
+
     activeDownloadAborts.delete(key)
   }
 

--- a/src/main/utils/huggingface.ts
+++ b/src/main/utils/huggingface.ts
@@ -66,6 +66,37 @@ const activeDownloadAborts = new Map<string, AbortController>()
 
 const getDownloadKey = (repo: string, filename: string): string => `${repo}::${filename}`
 
+const waitForWriteStreamClose = (writeStream: fs.WriteStream): Promise<void> => {
+  if (writeStream.closed) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    const onClose = () => {
+      cleanup()
+      resolve()
+    }
+
+    const onError = (error: Error) => {
+      cleanup()
+      reject(error)
+    }
+
+    const cleanup = () => {
+      writeStream.off('close', onClose)
+      writeStream.off('error', onError)
+    }
+
+    writeStream.once('close', onClose)
+    writeStream.once('error', onError)
+
+    if (writeStream.closed) {
+      cleanup()
+      resolve()
+    }
+  })
+}
+
 /**
  * Cancel the current download in progress.
  */
@@ -204,7 +235,7 @@ export const downloadModel = async (
     if (!writeStream.writableEnded) {
       writeStream.end()
     }
-    await new Promise((resolve) => writeStream.on('close', resolve))
+    await waitForWriteStreamClose(writeStream)
 
     if (!downloadSucceeded && fs.existsSync(tmpPath)) {
       try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -155,7 +155,8 @@ const api = {
     ipcRenderer.invoke('huggingface:models:download', repo, filename, token, expectedSize),
   deleteHfModel: (repo: string, filename: string) =>
     ipcRenderer.invoke('huggingface:models:delete', repo, filename),
-  cancelHfDownload: () => ipcRenderer.invoke('huggingface:models:cancel'),
+  cancelHfDownload: (repo?: string, filename?: string) =>
+    ipcRenderer.invoke('huggingface:models:cancel', repo, filename),
   searchHfModels: (query: string, token?: string) =>
     ipcRenderer.invoke('huggingface:search', query, token),
   getHfRepoFiles: (repo: string, token?: string) =>

--- a/src/renderer/src/lib/components/Main/Settings/Models.svelte
+++ b/src/renderer/src/lib/components/Main/Settings/Models.svelte
@@ -41,29 +41,104 @@
   let repoFiles = $state<HfFileInfo[]>([])
   let loadingFiles = $state(false)
 
-  // Download state — track active download in the "Downloaded" section
-  let activeDownload = $state<{ repo: string; filename: string; percent: number } | null>(null)
+  const MAX_CONCURRENT_DOWNLOADS = 3
 
-  onMount(async () => {
-    models = await window.electronAPI.listHfModels()
-    modelsDir = await window.electronAPI.getHfModelsDir() || ''
-    loaded = true
+  interface ActiveDownload {
+    repo: string
+    filename: string
+    size: number
+    percent: number
+    status: 'queued' | 'downloading'
+  }
 
-    window.electronAPI.onData((data: any) => {
-      if (data.type === 'status:huggingface-download') {
-        const d = data.data
-        if (d?.status === 'downloading') {
-          activeDownload = { repo: d.repo, filename: d.filename, percent: d.percent ?? 0 }
-        }
-        if (d?.status === 'done') {
-          activeDownload = null
-          window.electronAPI.listHfModels().then((m: HfModel[]) => { models = m })
-        }
-        if (d?.status === 'failed') {
-          activeDownload = null
-        }
+  let activeDownloads = $state<Record<string, ActiveDownload>>({})
+  let queuedDownloadKeys = $state<string[]>([])
+  const activeDownloadList = $derived(Object.values(activeDownloads))
+  const hasActiveDownloads = $derived(activeDownloadList.length > 0)
+
+  const getDownloadKey = (repo: string, filename: string): string => `${repo}::${filename}`
+
+  const removeLocalDownload = (key: string) => {
+    const next = { ...activeDownloads }
+    delete next[key]
+    activeDownloads = next
+    queuedDownloadKeys = queuedDownloadKeys.filter((k) => k !== key)
+  }
+
+  const startQueuedDownloads = () => {
+    const runningCount = Object.values(activeDownloads).filter(
+      (d) => d.status === 'downloading'
+    ).length
+    const availableSlots = Math.max(0, MAX_CONCURRENT_DOWNLOADS - runningCount)
+    if (!availableSlots) return
+
+    const toStart = queuedDownloadKeys.slice(0, availableSlots)
+    for (const key of toStart) {
+      const item = activeDownloads[key]
+      if (!item) {
+        queuedDownloadKeys = queuedDownloadKeys.filter((k) => k !== key)
+        continue
       }
-    })
+
+      activeDownloads = {
+        ...activeDownloads,
+        [key]: { ...item, status: 'downloading', percent: item.percent ?? 0 }
+      }
+      queuedDownloadKeys = queuedDownloadKeys.filter((k) => k !== key)
+
+      void window.electronAPI
+        .downloadHfModel(item.repo, item.filename, undefined, item.size)
+        .catch((e: any) => {
+          console.error('Failed to download model:', e)
+        })
+    }
+  }
+
+  onMount(() => {
+    let cleanupDataListener: (() => void) | null = null
+
+    const init = async () => {
+      models = await window.electronAPI.listHfModels()
+      modelsDir = (await window.electronAPI.getHfModelsDir()) || ''
+      loaded = true
+
+      cleanupDataListener = window.electronAPI.onData((data: any) => {
+        if (data.type === 'status:huggingface-download') {
+          const d = data.data
+          if (d?.status === 'downloading') {
+            const key = getDownloadKey(d.repo, d.filename)
+            const existing = activeDownloads[key]
+            activeDownloads = {
+              ...activeDownloads,
+              [key]: {
+                repo: d.repo,
+                filename: d.filename,
+                size: existing?.size ?? d.totalBytes ?? 0,
+                percent: d.percent ?? existing?.percent ?? 0,
+                status: 'downloading'
+              }
+            }
+          }
+          if (d?.status === 'done') {
+            removeLocalDownload(getDownloadKey(d.repo, d.filename))
+            window.electronAPI.listHfModels().then((m: HfModel[]) => {
+              models = m
+            })
+            startQueuedDownloads()
+          }
+          if (d?.status === 'failed') {
+            removeLocalDownload(getDownloadKey(d.repo, d.filename))
+            startQueuedDownloads()
+          }
+        }
+      })
+    }
+
+    void init()
+
+    return () => {
+      cleanupDataListener?.()
+    }
   })
 
   const onSearchInput = (e: Event) => {
@@ -108,23 +183,42 @@
     repoFiles = []
   }
 
-  const startDownload = async (repo: string, filename: string, size?: number) => {
-    activeDownload = { repo, filename, percent: 0 }
-    try {
-      await window.electronAPI.downloadHfModel(repo, filename, undefined, size)
-    } catch (e) {
-      console.error('Failed to download model:', e)
-      activeDownload = null
+  const startDownload = (repo: string, filename: string, size?: number) => {
+    const key = getDownloadKey(repo, filename)
+    if (activeDownloads[key] || queuedDownloadKeys.includes(key)) return
+
+    activeDownloads = {
+      ...activeDownloads,
+      [key]: {
+        repo,
+        filename,
+        size: size ?? 0,
+        percent: 0,
+        status: 'queued'
+      }
     }
+    queuedDownloadKeys = [...queuedDownloadKeys, key]
+    startQueuedDownloads()
   }
 
-  const cancelDownload = async () => {
+  const cancelDownload = async (repo: string, filename: string) => {
+    const key = getDownloadKey(repo, filename)
+    const active = activeDownloads[key]
+    if (!active) return
+
+    if (active.status === 'queued') {
+      removeLocalDownload(key)
+      return
+    }
+
     try {
-      await window.electronAPI.cancelHfDownload()
+      await window.electronAPI.cancelHfDownload(repo, filename)
     } catch (e) {
       console.error('Failed to cancel download:', e)
     }
-    activeDownload = null
+
+    removeLocalDownload(key)
+    startQueuedDownloads()
   }
 
   const removeModel = async (repo: string, filename: string) => {
@@ -143,7 +237,13 @@
   }
 
   const isDownloading = (repo: string, filename: string): boolean => {
-    return activeDownload?.repo === repo && activeDownload?.filename === filename
+    const key = getDownloadKey(repo, filename)
+    return activeDownloads[key]?.status === 'downloading'
+  }
+
+  const isQueued = (repo: string, filename: string): boolean => {
+    const key = getDownloadKey(repo, filename)
+    return activeDownloads[key]?.status === 'queued'
   }
 
   const formatSize = (bytes: number): string => {
@@ -164,207 +264,347 @@
 {#if !loaded}
   <div class="py-6 text-[12px] opacity-20 text-center">{$i18n.t('common.loading')}</div>
 {:else}
-<div class="flex flex-col divide-y divide-white/[0.04]">
-
-  <!-- Models directory -->
-  <div class="py-4 flex items-center justify-between gap-4">
-    <div class="shrink-0">
-      <div class="text-[13px] opacity-70">{$i18n.t('settings.models.modelsDirectory')}</div>
-      <div class="text-[11px] opacity-25 mt-0.5">{$i18n.t('settings.models.modelsHint')}</div>
-    </div>
-    <button class="text-[12px] font-mono hover:opacity-80 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-0 underline decoration-dotted underline-offset-2 cursor-pointer flex items-center gap-1.5 min-w-0 truncate" onclick={() => { if (modelsDir) window.electronAPI.openPath(modelsDir) }}>
-      <span class="truncate">{modelsDir || '…'}</span>
-      <svg class="w-3 h-3 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-      </svg>
-    </button>
-  </div>
-
-  <!-- Downloaded models + active download -->
-  <div class="py-4">
-    <div class="text-[12px] opacity-50 mb-2">{$i18n.t('settings.models.downloadedModels')}</div>
-
-    {#if models.length > 0 || activeDownload}
-      <div class="flex flex-col gap-1.5">
-
-        <!-- Active download in progress -->
-        {#if activeDownload}
-          <div class="px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] rounded-xl">
-            <div class="flex items-center justify-between gap-2 mb-1.5">
-              <div class="min-w-0 flex-1">
-                <div class="text-[12px] opacity-60 truncate font-mono">{activeDownload.filename}</div>
-                <div class="text-[10px] opacity-25 truncate">{activeDownload.repo} · {$i18n.t('common.downloading')}</div>
-              </div>
-              <button
-                class="opacity-30 hover:opacity-70 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-1 shrink-0"
-                onclick={cancelDownload}
-                title={$i18n.t('settings.models.cancelDownload')}
-              >
-                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div class="w-full h-1 bg-black/[0.06] dark:bg-white/[0.06] rounded-full overflow-hidden">
-              <div
-                class="h-full bg-emerald-400/80 rounded-full"
-                style="width: {activeDownload.percent}%"
-              ></div>
-            </div>
-            <div class="text-[10px] opacity-25 mt-1 text-right font-mono">{activeDownload.percent.toFixed(1)}%</div>
-          </div>
-        {/if}
-
-        <!-- Completed downloads -->
-        {#each models as model}
-          <div class="flex items-center justify-between gap-2 px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] rounded-xl">
-            <div class="min-w-0 flex-1">
-              <div class="text-[12px] opacity-60 truncate font-mono">{model.filename}</div>
-              <div class="text-[10px] opacity-25 truncate">{model.repo} · {formatSize(model.size)}</div>
-            </div>
-            <button
-              class="opacity-20 hover:opacity-60 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-1 shrink-0 {deleting === `${model.repo}/${model.filename}` ? 'pointer-events-none' : ''}"
-              onclick={() => removeModel(model.repo, model.filename)}
-              title={$i18n.t('settings.models.deleteModel')}
-            >
-              {#if deleting === `${model.repo}/${model.filename}`}
-                <div class="w-3 h-3 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin"></div>
-              {:else}
-                <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
-                </svg>
-              {/if}
-            </button>
-          </div>
-        {/each}
+  <div class="flex flex-col divide-y divide-white/[0.04]">
+    <!-- Models directory -->
+    <div class="py-4 flex items-center justify-between gap-4">
+      <div class="shrink-0">
+        <div class="text-[13px] opacity-70">{$i18n.t('settings.models.modelsDirectory')}</div>
+        <div class="text-[11px] opacity-25 mt-0.5">{$i18n.t('settings.models.modelsHint')}</div>
       </div>
-    {:else}
-      <div class="text-[11px] opacity-40 py-3">{$i18n.t('settings.models.noModels')}</div>
-    {/if}
-  </div>
-
-  <!-- Download from HF -->
-  <div class="py-4">
-    <div class="text-[12px] opacity-50 mb-2">
-      {#if selectedRepo}
-        <button
-          class="opacity-50 hover:opacity-80 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-0 text-[12px] flex items-center gap-1"
-          onclick={backToSearch}
+      <button
+        class="text-[12px] font-mono hover:opacity-80 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-0 underline decoration-dotted underline-offset-2 cursor-pointer flex items-center gap-1.5 min-w-0 truncate"
+        onclick={() => {
+          if (modelsDir) window.electronAPI.openPath(modelsDir)
+        }}
+      >
+        <span class="truncate">{modelsDir || '…'}</span>
+        <svg
+          class="w-3 h-3 shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.5"
         >
-          <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-          {$i18n.t('common.back')}
-        </button>
-      {:else}
-        {$i18n.t('settings.models.downloadFromHF')}
-      {/if}
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+          />
+        </svg>
+      </button>
     </div>
 
-    {#if selectedRepo}
-      <!-- Repo file browser -->
-      <div class="mb-2">
-        <div class="text-[12px] opacity-60 font-mono truncate mb-2">{selectedRepo}</div>
-      </div>
+    <!-- Downloaded models + active download -->
+    <div class="py-4">
+      <div class="text-[12px] opacity-50 mb-2">{$i18n.t('settings.models.downloadedModels')}</div>
 
-      {#if loadingFiles}
-        <div class="flex items-center gap-2 py-3 justify-center">
-          <div class="w-3 h-3 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin"></div>
-          <span class="text-[11px] opacity-30">{$i18n.t('settings.models.loadingFiles')}</span>
-        </div>
-      {:else if repoFiles.length === 0}
-        <div class="text-[11px] opacity-20 text-center py-3">{$i18n.t('settings.models.noGgufFiles')}</div>
-      {:else}
-        <div class="flex flex-col gap-1">
-          {#each repoFiles as file}
-            {@const downloaded = isDownloaded(selectedRepo, file.filename)}
-            {@const dlActive = isDownloading(selectedRepo, file.filename)}
-            <div class="flex items-center justify-between gap-2 px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] rounded-xl">
-              <div class="min-w-0 flex-1">
-                <div class="text-[12px] opacity-50 truncate font-mono">{file.filename}</div>
-                <div class="text-[10px] opacity-25">{formatSize(file.size)}</div>
-              </div>
-              {#if downloaded}
-                <span class="text-[10px] opacity-30 shrink-0 px-2">{$i18n.t('settings.models.downloaded')}</span>
-              {:else if dlActive}
-                <div class="flex items-center gap-1.5 shrink-0">
-                  <div class="w-2.5 h-2.5 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin"></div>
-                  <span class="text-[10px] opacity-40 font-mono">{activeDownload?.percent?.toFixed(0) ?? 0}%</span>
+      {#if models.length > 0 || hasActiveDownloads}
+        <div class="flex flex-col gap-1.5">
+          <!-- Active download in progress -->
+          {#each activeDownloadList as activeDownload (getDownloadKey(activeDownload.repo, activeDownload.filename))}
+            <div class="px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] rounded-xl">
+              <div class="flex items-center justify-between gap-2 mb-1.5">
+                <div class="min-w-0 flex-1">
+                  <div class="text-[12px] opacity-60 font-mono flex items-center gap-2 min-w-0">
+                    <span class="truncate min-w-0">{activeDownload.filename}</span>
+                    {#if activeDownload.size > 0}
+                      <span class="text-[10px] opacity-35 shrink-0"
+                        >{formatSize(activeDownload.size)}</span
+                      >
+                    {/if}
+                  </div>
+                  <div class="text-[10px] opacity-25 truncate">
+                    {activeDownload.repo} · {activeDownload.status === 'queued'
+                      ? 'Queued'
+                      : $i18n.t('common.downloading')}
+                  </div>
                 </div>
-              {:else}
                 <button
-                  class="opacity-30 hover:opacity-70 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-1 shrink-0 {activeDownload ? 'pointer-events-none opacity-10' : ''}"
-                  onclick={() => startDownload(selectedRepo, file.filename, file.size)}
-                  disabled={!!activeDownload}
-                  title={$i18n.t('common.download')}
+                  class="opacity-30 hover:opacity-70 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-1 shrink-0"
+                  onclick={() => cancelDownload(activeDownload.repo, activeDownload.filename)}
+                  title={$i18n.t('settings.models.cancelDownload')}
                 >
-                  <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                  <svg
+                    class="w-3 h-3"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>
-              {/if}
+              </div>
+              <div
+                class="w-full h-1 bg-black/[0.06] dark:bg-white/[0.06] rounded-full overflow-hidden"
+              >
+                <div
+                  class="h-full bg-emerald-400/80 rounded-full"
+                  style="width: {activeDownload.percent}%"
+                ></div>
+              </div>
+              <div class="text-[10px] opacity-25 mt-1 text-right font-mono">
+                {activeDownload.status === 'queued'
+                  ? 'queued'
+                  : `${activeDownload.percent.toFixed(1)}%`}
+              </div>
+            </div>
+          {/each}
+
+          <!-- Completed downloads -->
+          {#each models as model}
+            <div
+              class="flex items-center justify-between gap-2 px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] rounded-xl"
+            >
+              <div class="min-w-0 flex-1">
+                <div class="text-[12px] opacity-60 font-mono flex items-center gap-2 min-w-0">
+                  <span class="truncate min-w-0">{model.filename}</span>
+                </div>
+                <div class="text-[10px] opacity-25 truncate">
+                  {model.repo} · {formatSize(model.size)}
+                </div>
+              </div>
+              <button
+                class="opacity-20 hover:opacity-60 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-1 shrink-0 {deleting ===
+                `${model.repo}/${model.filename}`
+                  ? 'pointer-events-none'
+                  : ''}"
+                onclick={() => removeModel(model.repo, model.filename)}
+                title={$i18n.t('settings.models.deleteModel')}
+              >
+                {#if deleting === `${model.repo}/${model.filename}`}
+                  <div
+                    class="w-3 h-3 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin"
+                  ></div>
+                {:else}
+                  <svg
+                    class="w-3 h-3"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="1.5"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                    />
+                  </svg>
+                {/if}
+              </button>
             </div>
           {/each}
         </div>
+      {:else}
+        <div class="text-[11px] opacity-40 py-3">{$i18n.t('settings.models.noModels')}</div>
       {/if}
+    </div>
 
-    {:else}
-      <!-- Search -->
-      <div class="relative mb-2">
-        <svg class="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 opacity-25 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-        </svg>
-        <input
-          type="text"
-          class="bg-black/[0.04] dark:bg-white/[0.06] text-[12px] text-[#1d1d1f] dark:text-[#fafafa] pl-8 pr-3 py-2 border-none outline-none rounded-xl opacity-70 w-full"
-          placeholder={$i18n.t('settings.models.searchPlaceholder')}
-          value={searchQuery}
-          oninput={onSearchInput}
-        />
-        {#if searching}
-          <div class="w-3 h-3 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin absolute right-2.5 top-1/2 -translate-y-1/2"></div>
+    <!-- Download from HF -->
+    <div class="py-4">
+      <div class="text-[12px] opacity-50 mb-2">
+        {#if selectedRepo}
+          <button
+            class="opacity-50 hover:opacity-80 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-0 text-[12px] flex items-center gap-1"
+            onclick={backToSearch}
+          >
+            <svg
+              class="w-3 h-3"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M15.75 19.5L8.25 12l7.5-7.5"
+              />
+            </svg>
+            {$i18n.t('common.back')}
+          </button>
+        {:else}
+          {$i18n.t('settings.models.downloadFromHF')}
         {/if}
       </div>
 
-      {#if searchError}
-        <div class="text-[11px] text-red-400/70 text-center py-2">{searchError}</div>
-      {:else if searchResults.length > 0}
-        <div class="flex flex-col gap-1 max-h-[300px] overflow-y-auto">
-          {#each searchResults as repo}
-            <button
-              class="flex items-center justify-between gap-2 px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] hover:bg-black/[0.06] dark:hover:bg-white/[0.08] rounded-xl transition border-none text-left w-full text-[#1d1d1f] dark:text-[#fafafa]"
-              onclick={() => selectRepo(repo.id)}
-            >
-              <div class="min-w-0 flex-1">
-                <div class="text-[12px] opacity-60 truncate">{repo.id}</div>
-                <div class="text-[10px] opacity-25 flex items-center gap-2 mt-0.5">
-                  <span class="flex items-center gap-0.5">
-                    <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
-                    </svg>
-                    {formatDownloads(repo.downloads)}
-                  </span>
-                  <span class="flex items-center gap-0.5">
-                    <svg class="w-2.5 h-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
-                    </svg>
-                    {repo.likes}
-                  </span>
-                </div>
-              </div>
-              <svg class="w-3 h-3 opacity-20 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-              </svg>
-            </button>
-          {/each}
+      {#if selectedRepo}
+        <!-- Repo file browser -->
+        <div class="mb-2">
+          <div class="text-[12px] opacity-60 font-mono truncate mb-2">{selectedRepo}</div>
         </div>
-      {:else if searchQuery.trim() && !searching}
-        <div class="text-[11px] opacity-20 text-center py-3">{$i18n.t('settings.models.noReposFound')}</div>
-      {:else if !searchQuery.trim()}
-        <div class="text-[11px] opacity-20 text-center py-3">{$i18n.t('settings.models.searchForModels')}</div>
-      {/if}
-    {/if}
-  </div>
 
-</div>
+        {#if loadingFiles}
+          <div class="flex items-center gap-2 py-3 justify-center">
+            <div
+              class="w-3 h-3 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin"
+            ></div>
+            <span class="text-[11px] opacity-30">{$i18n.t('settings.models.loadingFiles')}</span>
+          </div>
+        {:else if repoFiles.length === 0}
+          <div class="text-[11px] opacity-20 text-center py-3">
+            {$i18n.t('settings.models.noGgufFiles')}
+          </div>
+        {:else}
+          <div class="flex flex-col gap-1">
+            {#each repoFiles as file}
+              {@const downloaded = isDownloaded(selectedRepo, file.filename)}
+              {@const dlActive = isDownloading(selectedRepo, file.filename)}
+              {@const dlQueued = isQueued(selectedRepo, file.filename)}
+              {@const key = getDownloadKey(selectedRepo, file.filename)}
+              <div
+                class="flex items-center justify-between gap-2 px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] rounded-xl"
+              >
+                <div class="min-w-0 flex-1">
+                  <div class="text-[12px] opacity-50 font-mono flex items-center gap-2 min-w-0">
+                    <span class="truncate min-w-0">{file.filename}</span>
+                    <span class="text-[10px] opacity-35 shrink-0">{formatSize(file.size)}</span>
+                  </div>
+                </div>
+                {#if downloaded}
+                  <span class="text-[10px] opacity-30 shrink-0 px-2"
+                    >{$i18n.t('settings.models.downloaded')}</span
+                  >
+                {:else if dlActive}
+                  <div class="flex items-center gap-1.5 shrink-0">
+                    <div
+                      class="w-2.5 h-2.5 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin"
+                    ></div>
+                    <span class="text-[10px] opacity-40 font-mono"
+                      >{activeDownloads[key]?.percent?.toFixed(0) ?? 0}%</span
+                    >
+                  </div>
+                {:else if dlQueued}
+                  <div class="flex items-center gap-1.5 shrink-0">
+                    <span class="text-[10px] opacity-35 font-mono">queued</span>
+                  </div>
+                {:else}
+                  <button
+                    class="opacity-30 hover:opacity-70 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-1 shrink-0"
+                    onclick={() => startDownload(selectedRepo, file.filename, file.size)}
+                    title={$i18n.t('common.download')}
+                  >
+                    <svg
+                      class="w-3.5 h-3.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      stroke-width="1.5"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                      />
+                    </svg>
+                  </button>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {:else}
+        <!-- Search -->
+        <div class="relative mb-2">
+          <svg
+            class="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 opacity-25 pointer-events-none"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.5"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
+          </svg>
+          <input
+            type="text"
+            class="bg-black/[0.04] dark:bg-white/[0.06] text-[12px] text-[#1d1d1f] dark:text-[#fafafa] pl-8 pr-3 py-2 border-none outline-none rounded-xl opacity-70 w-full"
+            placeholder={$i18n.t('settings.models.searchPlaceholder')}
+            value={searchQuery}
+            oninput={onSearchInput}
+          />
+          {#if searching}
+            <div
+              class="w-3 h-3 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin absolute right-2.5 top-1/2 -translate-y-1/2"
+            ></div>
+          {/if}
+        </div>
+
+        {#if searchError}
+          <div class="text-[11px] text-red-400/70 text-center py-2">{searchError}</div>
+        {:else if searchResults.length > 0}
+          <div class="flex flex-col gap-1 max-h-[300px] overflow-y-auto">
+            {#each searchResults as repo}
+              <button
+                class="flex items-center justify-between gap-2 px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] hover:bg-black/[0.06] dark:hover:bg-white/[0.08] rounded-xl transition border-none text-left w-full text-[#1d1d1f] dark:text-[#fafafa]"
+                onclick={() => selectRepo(repo.id)}
+              >
+                <div class="min-w-0 flex-1">
+                  <div class="text-[12px] opacity-60 truncate">{repo.id}</div>
+                  <div class="text-[10px] opacity-25 flex items-center gap-2 mt-0.5">
+                    <span class="flex items-center gap-0.5">
+                      <svg
+                        class="w-2.5 h-2.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                        />
+                      </svg>
+                      {formatDownloads(repo.downloads)}
+                    </span>
+                    <span class="flex items-center gap-0.5">
+                      <svg
+                        class="w-2.5 h-2.5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="1.5"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+                        />
+                      </svg>
+                      {repo.likes}
+                    </span>
+                  </div>
+                </div>
+                <svg
+                  class="w-3 h-3 opacity-20 shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M8.25 4.5l7.5 7.5-7.5 7.5"
+                  />
+                </svg>
+              </button>
+            {/each}
+          </div>
+        {:else if searchQuery.trim() && !searching}
+          <div class="text-[11px] opacity-20 text-center py-3">
+            {$i18n.t('settings.models.noReposFound')}
+          </div>
+        {:else if !searchQuery.trim()}
+          <div class="text-[11px] opacity-20 text-center py-3">
+            {$i18n.t('settings.models.searchForModels')}
+          </div>
+        {/if}
+      {/if}
+    </div>
+  </div>
 {/if}

--- a/src/renderer/src/lib/components/Main/Settings/Models.svelte
+++ b/src/renderer/src/lib/components/Main/Settings/Models.svelte
@@ -408,19 +408,6 @@
             class="opacity-50 hover:opacity-80 transition bg-transparent border-none text-[#1d1d1f] dark:text-[#fafafa] p-0 text-[12px] flex items-center gap-1"
             onclick={backToSearch}
           >
-            <svg
-              class="w-3 h-3"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M15.75 19.5L8.25 12l7.5-7.5"
-              />
-            </svg>
             {$i18n.t('common.back')}
           </button>
         {:else}

--- a/src/renderer/src/lib/components/Main/Settings/Models.svelte
+++ b/src/renderer/src/lib/components/Main/Settings/Models.svelte
@@ -48,7 +48,7 @@
     filename: string
     size: number
     percent: number
-    status: 'queued' | 'downloading'
+    status: 'queued' | 'downloading' | 'cancelling'
   }
 
   let activeDownloads = $state<Record<string, ActiveDownload>>({})
@@ -67,7 +67,7 @@
 
   const startQueuedDownloads = () => {
     const runningCount = Object.values(activeDownloads).filter(
-      (d) => d.status === 'downloading'
+      (d) => d.status === 'downloading' || d.status === 'cancelling'
     ).length
     const availableSlots = Math.max(0, MAX_CONCURRENT_DOWNLOADS - runningCount)
     if (!availableSlots) return
@@ -115,7 +115,7 @@
                 filename: d.filename,
                 size: existing?.size ?? d.totalBytes ?? 0,
                 percent: d.percent ?? existing?.percent ?? 0,
-                status: 'downloading'
+                status: existing?.status === 'cancelling' ? 'cancelling' : 'downloading'
               }
             }
           }
@@ -211,14 +211,41 @@
       return
     }
 
-    try {
-      await window.electronAPI.cancelHfDownload(repo, filename)
-    } catch (e) {
-      console.error('Failed to cancel download:', e)
+    activeDownloads = {
+      ...activeDownloads,
+      [key]: {
+        ...active,
+        status: 'cancelling'
+      }
     }
 
-    removeLocalDownload(key)
-    startQueuedDownloads()
+    try {
+      const cancelled = await window.electronAPI.cancelHfDownload(repo, filename)
+      if (!cancelled) {
+        const latest = activeDownloads[key]
+        if (latest) {
+          activeDownloads = {
+            ...activeDownloads,
+            [key]: {
+              ...latest,
+              status: 'downloading'
+            }
+          }
+        }
+      }
+    } catch (e) {
+      console.error('Failed to cancel download:', e)
+      const latest = activeDownloads[key]
+      if (latest) {
+        activeDownloads = {
+          ...activeDownloads,
+          [key]: {
+            ...latest,
+            status: 'downloading'
+          }
+        }
+      }
+    }
   }
 
   const removeModel = async (repo: string, filename: string) => {
@@ -244,6 +271,11 @@
   const isQueued = (repo: string, filename: string): boolean => {
     const key = getDownloadKey(repo, filename)
     return activeDownloads[key]?.status === 'queued'
+  }
+
+  const isCancelling = (repo: string, filename: string): boolean => {
+    const key = getDownloadKey(repo, filename)
+    return activeDownloads[key]?.status === 'cancelling'
   }
 
   const formatSize = (bytes: number): string => {
@@ -316,7 +348,9 @@
                   <div class="text-[10px] opacity-25 truncate">
                     {activeDownload.repo} · {activeDownload.status === 'queued'
                       ? 'Queued'
-                      : $i18n.t('common.downloading')}
+                      : activeDownload.status === 'cancelling'
+                        ? 'Cancelling'
+                        : $i18n.t('common.downloading')}
                   </div>
                 </div>
                 <button
@@ -346,7 +380,9 @@
               <div class="text-[10px] opacity-25 mt-1 text-right font-mono">
                 {activeDownload.status === 'queued'
                   ? 'queued'
-                  : `${activeDownload.percent.toFixed(1)}%`}
+                  : activeDownload.status === 'cancelling'
+                    ? 'cancelling'
+                    : `${activeDownload.percent.toFixed(1)}%`}
               </div>
             </div>
           {/each}
@@ -438,6 +474,7 @@
               {@const downloaded = isDownloaded(selectedRepo, file.filename)}
               {@const dlActive = isDownloading(selectedRepo, file.filename)}
               {@const dlQueued = isQueued(selectedRepo, file.filename)}
+              {@const dlCancelling = isCancelling(selectedRepo, file.filename)}
               {@const key = getDownloadKey(selectedRepo, file.filename)}
               <div
                 class="flex items-center justify-between gap-2 px-2.5 py-2 bg-black/[0.03] dark:bg-white/[0.04] rounded-xl"
@@ -464,6 +501,13 @@
                 {:else if dlQueued}
                   <div class="flex items-center gap-1.5 shrink-0">
                     <span class="text-[10px] opacity-35 font-mono">queued</span>
+                  </div>
+                {:else if dlCancelling}
+                  <div class="flex items-center gap-1.5 shrink-0">
+                    <div
+                      class="w-2.5 h-2.5 rounded-full border-[1.5px] border-black/20 dark:border-white/30 border-t-transparent animate-spin"
+                    ></div>
+                    <span class="text-[10px] opacity-35 font-mono">cancelling</span>
                   </div>
                 {:else}
                   <button


### PR DESCRIPTION
## Description

- add concurrent model downloads in settings (max 3 at a time; slightly arbitrary) with queued state
- show file size next to model files in repo list
- remove duplicate back arrow in model repo view

<img width="1005" height="628" alt="image" src="https://github.com/user-attachments/assets/020b4d9f-bb66-4cfd-87b1-2be97eace35b" />

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/desktop/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
