### PR TITLE
fix: resolve mac spotlight new chat bug

### DIFF
--- a/src/renderer/src/lib/components/Main/Connections.svelte
+++ b/src/renderer/src/lib/components/Main/Connections.svelte
@@ -401,9 +401,24 @@
         activeConnectionId = connId
         if (installPhase !== 'working') view = 'connected'
 
-        // Targeted delivery — wait a frame for the webview DOM to exist
         requestAnimationFrame(() => {
-          sendToWebview({ type: 'query', data: { query, files } }, connId)
+          const container = document.querySelector('.content-webview-container')
+          if (!container) return
+          const wv = container.querySelector(
+            `webview[partition="persist:connection-${connId}"]`
+          ) as any
+          if (!wv) return
+
+          if (query) {
+            const base = (openConnections.get(connId) ?? baseUrl).replace(/\/$/, '')
+            if (wv.loadURL) {
+              wv.loadURL(`${base}/?q=${encodeURIComponent(query)}`)
+            }
+          }
+
+          if (files?.length) {
+            sendToWebview({ type: 'query', data: { query, files } }, connId)
+          }
         })
         return
       }


### PR DESCRIPTION
## Description

When testing out the new desktop app, I discovered that the spotlight-esque overlay input would accept text but just open a blank chat rather than actually starting it.

The spotlight query handler sent an IPC event `({type: 'query', data: {query, files}})` to the Open WebUI webview via sendToWebview(). However, Open WebUI's desktopEventHandler in +layout.svelte doesn't handle the query event type, it only handles `page:reload, page:navigate, models:refresh, connections:terminal, and connections:openai`. The event was silently dropped, so the main window showed up with a blank/unstarted chat.

**Fix:** Navigate the webview to /?q=<query> instead. Open WebUI natively supports this URL parameter in Chat.svelte (line 1248-1257) — it reads the q param, sets the message input, and auto-submits it via submitPrompt(). File attachments (screenshots) still go through the IPC event path since they can't be passed via URL.

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/desktop/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
