### PR TITLE
fix: add disable-library-validation entitlement for macOS

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.cs.allow-dyld-environment-variables</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Adds `com.apple.security.cs.disable-library-validation` entitlement to `build/entitlements.mac.plist`
- Fixes app crash at launch on macOS caused by DYLD Team ID mismatch between the main binary and Electron Framework

## Context

The app fails to launch with:

```
Library not loaded: @rpath/Electron Framework.framework/Electron Framework
Reason: mapping process and mapped file (non-platform) have different Team IDs
```

macOS enforces that loaded dylibs must share the same Team ID as the host binary unless the app opts out via `com.apple.security.cs.disable-library-validation`. This is standard practice for Electron apps.

## Test plan

- [x] Built and packaged the app (`npx electron-builder --mac --dir`)
- [x] Verified entitlement is embedded (`codesign -d --entitlements -`)
- [x] Launched the app — no crash, process stays running
- [x] Confirmed no new crash reports in `~/Library/Logs/DiagnosticReports/`