### PR TITLE
(fix) url links open in the default browser

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,7 +15,8 @@ import {
   Menu,
   ipcMain,
   Tray,
-  dialog
+  dialog,
+  webContents
 } from 'electron'
 import path, { join } from 'path'
 import { readFile, statfs } from 'fs/promises'
@@ -675,6 +676,13 @@ function createMainWindow(show = true): void {
   mainWindow.webContents.setWindowOpenHandler((details) => {
     openUrl(details.url)
     return { action: 'deny' }
+  })
+
+  mainWindow.webContents.on('did-attach-webview', (_event, webContents) => {
+    webContents.setWindowOpenHandler((details) => {
+      openUrl(details.url)
+      return { action: 'deny' }
+    })
   })
 
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {


### PR DESCRIPTION
## Description

URL links in chats now open in default browser.

## Related Issues

https://github.com/open-webui/desktop/issues/165#issuecomment-4363555920

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [X] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/desktop/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
