### PR TITLE
feat: upgrade Flatpak runtime to 25.08

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -66,9 +66,9 @@ appImage:
   artifactName: ${name}_${arch}.${ext}
 flatpak:
   base: org.electronjs.Electron2.BaseApp
-  baseVersion: '23.08'
+  baseVersion: '25.08'
   runtime: org.freedesktop.Platform
-  runtimeVersion: '23.08'
+  runtimeVersion: '25.08'
   sdk: org.freedesktop.Sdk
   artifactName: ${name}.flatpak
   finishArgs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-webui",
-  "version": "0.0.3",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-webui",
-      "version": "0.0.3",
+      "version": "0.0.20",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win",
     "build:mac": "npm run build && electron-builder --mac",
-    "build:linux": "npm run build && electron-builder --linux"
+    "build:linux": "npm run build && electron-builder --linux",
+    "build:flatpak": "npm run build && electron-builder --linux flatpak"
   },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",


### PR DESCRIPTION
## Description

- Bumps the Flatpak runtime (`org.freedesktop.Platform`) from the deprecated 23.08 to 25.08.
- Updated `flatpak.baseVersion` and `runtimeVersion` in `electron-builder.yml` from `'23.08'` to `'25.08'`
- Adds dedicated `build:flatpak` npm script for building `.flatpak` bundles
- Generates bundle at `dist/open-webui.flatpak` (~92 MB)
- I installed/tested the generated the flatpak bundle on my laptop and it is working properly. 
- The next step would be testing this change on the CI/CD Github pipeline. 

### Install required runtime and SDK
```bash 
sudo apt-get update && sudo apt-get install -y flatpak flatpak-builder 
flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
flatpak --user install -y flathub org.freedesktop.Platform//25.08 org.freedesktop.Sdk//25.08 org.electronjs.Electron2.BaseApp//25.08 
```
#### Build Process
```bash  
 npm install
 npm run build:flatpak
```

## Related Issues

- The main issue this PR resolves for me was the dependency on the deprecated 23.08 runtime,  I didn't wanted to install that dependency.
- The size of the Flathub version of this app for some reason is around 800 MB, I didn't wanted to download that. 

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/desktop/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
