### PR TITLE
fix: allow OAuth popups to open inside Electron webview

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1313,7 +1313,20 @@ if (!gotTheLock) {
 
       if (contents.getType() === 'webview') {
         // ── Popups (target="_blank" links) → open in default browser ──
+        // OAuth popup windows (Google, Microsoft, GitHub, etc.) must open
+        // inside Electron so the opener page can receive the postMessage
+        // callback. All other popups go to the system browser.
+        const OAUTH_HOSTS = [
+          'accounts.google.com',
+          'login.microsoftonline.com',
+          'github.com/login',
+          'github.com/oauth',
+        ]
         contents.setWindowOpenHandler(({ url }) => {
+          const isOAuth = OAUTH_HOSTS.some((h) => url.includes(h))
+          if (isOAuth) {
+            return { action: 'allow' }
+          }
           openUrl(url)
           return { action: 'deny' }
         })


### PR DESCRIPTION
## Description

OAuth popups (Google Drive, Google Sign-In, etc.) are blocked when triggered
from a webview because `setWindowOpenHandler` returns `{ action: 'deny' }` for
all popups. The popup opens in the system browser instead, which breaks the
OAuth handshake, the opener page can't receive the postMessage callback from
an external browser window.

Fix: whitelist known OAuth provider hosts so their popups open as child windows
inside Electron, where the callback can complete normally. All other popups
continue to open in the system browser.

## Related Issues
Closes #175

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/desktop/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
