### PR TITLE
Add CUDA 13.3 and 13.4 variant support to Inference Runtime settings

### DIFF
--- a/src/main/utils/llamacpp.ts
+++ b/src/main/utils/llamacpp.ts
@@ -165,6 +165,8 @@ const getAssetPattern = (tag: string, variant: string): { pattern: string; isZip
       cpu: `llama-${tag}-bin-win-cpu-${archStr}.zip`,
       'cuda-12.4': `llama-${tag}-bin-win-cuda-12.4-x64.zip`,
       'cuda-13.1': `llama-${tag}-bin-win-cuda-13.1-x64.zip`,
+      'cuda-13.3': `llama-${tag}-bin-win-cuda-13.3-x64.zip`,   // new
+      'cuda-13.4': `llama-${tag}-bin-win-cuda-13.4-x64.zip`,   // new
       vulkan: `llama-${tag}-bin-win-vulkan-x64.zip`
     }
     const name = variantMap[variant] ?? variantMap.cpu

--- a/src/renderer/src/lib/components/Main/Settings/InferenceRuntime.svelte
+++ b/src/renderer/src/lib/components/Main/Settings/InferenceRuntime.svelte
@@ -61,8 +61,8 @@
       { value: 'cpu', label: $i18n.t('settings.inference.variantCPU') },
       { value: 'cuda-12.4', label: 'CUDA 12.4' },
       { value: 'cuda-13.1', label: 'CUDA 13.1' },
-      { value: 'cuda-13.3', label: 'CUDA 13.3' },   // new
-      { value: 'cuda-13.4', label: 'CUDA 13.4' },   // new
+      { value: 'cuda-13.3', label: 'CUDA 13.3' },
+      { value: 'cuda-13.4', label: 'CUDA 13.4' },
       { value: 'vulkan', label: 'Vulkan' }
     ]
     return [

--- a/src/renderer/src/lib/components/Main/Settings/InferenceRuntime.svelte
+++ b/src/renderer/src/lib/components/Main/Settings/InferenceRuntime.svelte
@@ -61,6 +61,8 @@
       { value: 'cpu', label: $i18n.t('settings.inference.variantCPU') },
       { value: 'cuda-12.4', label: 'CUDA 12.4' },
       { value: 'cuda-13.1', label: 'CUDA 13.1' },
+      { value: 'cuda-13.3', label: 'CUDA 13.3' },   // new
+      { value: 'cuda-13.4', label: 'CUDA 13.4' },   // new
       { value: 'vulkan', label: 'Vulkan' }
     ]
     return [


### PR DESCRIPTION
## Description

The Inference Runtime settings only offered CUDA 12.4 and CUDA 13.1 as
llama.cpp variants. Recent llama.cpp releases (e.g. b10666) ship CUDA 13.3
and 13.4 Windows builds, so users on newer GPUs/drivers had no way to select
them and would fall back to CPU-only inference.

This PR adds `cuda-13.3` and `cuda-13.4` as additional pinned variant
options, alongside the existing `cuda-12.4` and `cuda-13.1` — same pattern,
same exact-match asset resolution already used in `getAssetPattern()`.
Nothing existing was changed or removed, so pinning an older release tag
(via the Release Version field) that only shipped `cuda-13.1` still resolves
correctly.

## Related Issues

Fixes #264

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/desktop/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
