### PR TITLE
fix: harden desktop shell against untrusted webviews and supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: Typecheck, tests, and main lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+      - run: npx eslint src/main src/preload --max-warnings 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,17 +91,18 @@ jobs:
                   flatpak install --user -y flathub org.electronjs.Electron2.BaseApp//23.08
 
             # ── Apple codesigning (macOS only) ──
+            # Missing certs or notarization failure fail the job. Unsigned
+            # macOS/Windows artifacts are not published.
             - name: Install Apple codesigning certificate
               id: apple_cert
               if: matrix.os == 'macos-latest'
-              continue-on-error: true
               env:
                   BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
                   P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
                   KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
               run: |
                   if [ -z "$BUILD_CERTIFICATE_BASE64" ]; then
-                    echo "No certificate provided, will build unsigned"
+                    echo "BUILD_CERTIFICATE_BASE64 is required; refusing to ship an unsigned macOS build"
                     exit 1
                   fi
                   CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
@@ -116,24 +117,13 @@ jobs:
 
             # ── Platform packaging ──
             - name: Package for Windows
-              id: win_build
               if: runner.os == 'Windows'
-              continue-on-error: true
+              env:
+                  CSC_IDENTITY_AUTO_DISCOVERY: 'false'
               run: npx electron-builder --win --${{ matrix.arch }} --publish never
 
-            - name: Package for Windows (unsigned fallback)
-              if: runner.os == 'Windows' && steps.win_build.outcome == 'failure'
-              env:
-                  WIN_CSC_LINK: ''
-                  CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-              run: |
-                  rm -rf dist/
-                  npx electron-builder --win --${{ matrix.arch }} --publish never
-
             - name: Package for macOS (signed + notarized)
-              id: mac_build
-              if: matrix.os == 'macos-latest' && steps.apple_cert.outcome == 'success'
-              continue-on-error: true
+              if: matrix.os == 'macos-latest'
               env:
                   CSC_LINK: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
                   CSC_KEY_PASSWORD: ${{ secrets.P12_PASSWORD }}
@@ -141,14 +131,6 @@ jobs:
                   APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
                   APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
               run: npx electron-builder --mac --${{ matrix.arch }} -c.mac.notarize=true --publish never
-
-            - name: Package for macOS (unsigned fallback)
-              if: matrix.os == 'macos-latest' && (steps.apple_cert.outcome != 'success' || steps.mac_build.outcome == 'failure')
-              env:
-                  CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-              run: |
-                  rm -rf dist/
-                  npx electron-builder --mac --${{ matrix.arch }} --publish never
 
             - name: Package for Linux
               if: runner.os == 'Linux'
@@ -166,7 +148,6 @@ jobs:
             # ── Windows code signing ──
             - name: Azure Trusted Signing (Windows Only)
               if: runner.os == 'Windows'
-              continue-on-error: true
               uses: azure/trusted-signing-action@v0.5.1
               with:
                   azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- PTY resize/write after the child has exited is ignored instead of throwing an uncaught main-process exception (`Cannot resize a pty that has already exited` on Windows; ioctl EBADF on Linux) (#255).
 - Cloudflare Access / SSO login stays in the app (auth popups share the guest session; after the Access callback the webview loads the connection URL). Chat links still open externally (#165).
 - Tray Quit actually exits (`will-quit` ends with `app.exit`).
 - Open WebUI guest no longer dies on `appData is not defined` (`app:data` returns `null`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- Guest `<webview>` `send()` is allowlisted (`token:update`, `app:info`, `app:data`, `window:isFocused`). The previous `electronAPI[type]` dispatch let a remote Open WebUI page call privileged desktop APIs. `will-attach-webview` now forces sandbox / contextIsolation / no Node.
+- Open Terminal API keys and the llama.cpp endpoint are no longer broadcast to remote webviews.
+- TLS verification is on by default. Self-signed Open WebUI servers are still allowed, but only for origins the user added as connections (plus localhost).
+- `shell.openExternal` accepts only `http:`, `https:`, and `mailto:`. `open:path` is confined to userData / install dir.
+- Hugging Face repo ids and GGUF filenames are confined to the models cache. GGUF downloads are SHA-256 verified against the Hub LFS digest (`?blobs=true`).
+- Python standalone and llama.cpp GitHub assets are checksum-verified before extract.
+- Child-process env strips `LD_PRELOAD` / `NODE_OPTIONS` / `PYTHONHOME` / similar. llama.cpp `--host` / `--port` / `--models-dir` in extra args are ignored.
+- Linux `--no-sandbox` is only for AppImage, snap, Flatpak, unpackaged dev, or `ELECTRON_DISABLE_SANDBOX=1`. Native `.deb` / `.rpm` keep the renderer sandbox.
+- Packaged builds flip Electron fuses (`runAsNode` off, no `NODE_OPTIONS` / `--inspect`, no extra `file:` privileges, ASAR integrity on macOS/Windows).
+- Shell BrowserWindows use `sandbox: true`. The renderer no longer gets `@electron-toolkit/preload`'s `window.electron` (`ipcRenderer`).
+- Production shell loads `app://renderer/…` instead of `file://`.
+- Electron is pinned to 39.8.10 (GHSA-h7rp-cf8h-j98x / CVE-2026-70601).
+
+### Fixed
+
+- Cloudflare Access / SSO login stays in the app (auth popups share the guest session; after the Access callback the webview loads the connection URL). Chat links still open externally (#165).
+- Tray Quit actually exits (`will-quit` ends with `app.exit`).
+- Open WebUI guest no longer dies on `appData is not defined` (`app:data` returns `null`).
+- llama.cpp "latest" picks the newest GitHub release that actually has hashed `*-bin-*` assets (`/releases/latest` can be a tag with no binaries).
+- Quit waits for llama.cpp / Open Terminal / Open WebUI child processes.
+- macOS and Windows releases fail if codesign/notarization or Azure Trusted Signing fails, instead of publishing unsigned fallbacks.
+
+### Infrastructure
+
+- `npm test` covers main-process security helpers (`node:test`). CI runs typecheck, tests, and eslint on `src/main` + preload.
+
 ## [0.0.20] - 2026-05-07
 
 ### Fixed

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,6 +16,16 @@ extraResources:
 asarUnpack:
   - resources/**
   - node_modules/node-pty/**
+# Flip Chromium/Electron security fuses at pack time. runAsNode off blocks
+# ELECTRON_RUN_AS_NODE=1 (the app does not use process.fork). ASAR integrity
+# is macOS + Windows; Linux still gets the other fuses.
+electronFuses:
+  runAsNode: false
+  enableNodeOptionsEnvironmentVariable: false
+  enableNodeCliInspectArguments: false
+  enableEmbeddedAsarIntegrityValidation: true
+  onlyLoadAppFromAsar: true
+  grantFileProtocolExtraPrivileges: false
 win:
   executableName: open-webui
 nsis:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,5 +21,23 @@ export default defineConfig(
       'svelte/no-unused-svelte-ignore': 'off'
     }
   },
-  eslintConfigPrettier
+  eslintConfigPrettier,
+  {
+    // CI gates src/main + preload at zero findings. Toolkit recommended still
+    // has dozens of pre-existing any/return-type hits; prettier --fix would
+    // rewrite those files for style only. Renderer is not a CI lint path yet.
+    files: ['src/main/**/*.{ts,js}', 'src/preload/**/*.{ts,js}'],
+    rules: {
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-require-imports': 'off',
+      '@typescript-eslint/no-unsafe-function-type': 'off',
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+      ],
+      'prettier/prettier': 'off'
+    }
+  }
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "open-webui",
-  "version": "0.0.3",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-webui",
-      "version": "0.0.3",
+      "version": "0.0.20",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
-        "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@tailwindcss/vite": "^4.2.1",
         "@xterm/addon-fit": "^0.11.0",
@@ -32,7 +31,7 @@
         "@electron-toolkit/tsconfig": "^2.0.0",
         "@sveltejs/vite-plugin-svelte": "^6.2.0",
         "@types/node": "^22.19.1",
-        "electron": "^39.2.6",
+        "electron": "39.8.10",
         "electron-builder": "^26.0.12",
         "electron-vite": "^5.0.0",
         "eslint": "^9.39.1",
@@ -372,15 +371,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@electron-toolkit/preload": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@electron-toolkit/preload/-/preload-3.0.2.tgz",
-      "integrity": "sha512-TWWPToXd8qPRfSXwzf5KVhpXMfONaUuRAZJHsKthKgZR/+LqX1dZVSSClQ8OTAEduvLGdecljCsoT2jSshfoUg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "electron": ">=13.0.0"
       }
     },
     "node_modules/@electron-toolkit/tsconfig": {
@@ -4335,9 +4325,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.8.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.2.tgz",
-      "integrity": "sha512-uwNJHeqm8pzQEZf/KX4XM1fJctZpHcA0Za/MlP9mOg0FAWHbKo6yRC33QbdfLX7PeNjYZC3I3nnVhE5L2CLqxw==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -9344,23 +9334,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
   "scripts": {
     "format": "prettier --plugin prettier-plugin-svelte --write .",
     "lint": "eslint --cache .",
+    "lint:main": "eslint src/main src/preload --max-warnings 0",
     "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
     "svelte-check": "svelte-check --tsconfig ./tsconfig.json",
     "typecheck": "npm run typecheck:node && npm run svelte-check",
+    "test": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test test/*.test.ts",
     "start": "electron-vite preview",
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
@@ -22,7 +24,6 @@
     "build:linux": "npm run build && electron-builder --linux"
   },
   "dependencies": {
-    "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@tailwindcss/vite": "^4.2.1",
     "@xterm/addon-fit": "^0.11.0",
@@ -44,7 +45,7 @@
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@sveltejs/vite-plugin-svelte": "^6.2.0",
     "@types/node": "^22.19.1",
-    "electron": "^39.2.6",
+    "electron": "39.8.10",
     "electron-builder": "^26.0.12",
     "electron-vite": "^5.0.0",
     "eslint": "^9.39.1",

--- a/src/main/app-protocol.ts
+++ b/src/main/app-protocol.ts
@@ -1,0 +1,82 @@
+import path from 'path'
+import { pathToFileURL } from 'url'
+import { isPathInside } from './safe-open'
+
+export const APP_SCHEME = 'app'
+export const APP_HOST = 'renderer'
+
+export type ShellPage = 'index.html' | 'spotlight.html' | 'voice-input.html'
+
+export function rendererRoot(): string {
+  return path.join(__dirname, '../renderer')
+}
+
+export function shellPageUrl(page: ShellPage): string {
+  return `${APP_SCHEME}://${APP_HOST}/${page}`
+}
+
+/**
+ * Map an app:// URL to a file under the renderer out dir, or null if it
+ * must not be served (wrong host, traversal, empty path).
+ */
+export function resolveAppProtocolPath(
+  requestUrl: string,
+  root: string = rendererRoot()
+): string | null {
+  let url: URL
+  try {
+    url = new URL(requestUrl)
+  } catch {
+    return null
+  }
+  if (url.protocol !== `${APP_SCHEME}:`) return null
+  if (url.hostname !== APP_HOST) return null
+  if (url.port !== '' || url.username || url.password) return null
+
+  const relative = decodeURIComponent(url.pathname).replace(/^\/+/, '')
+  if (!relative || relative.includes('\0')) return null
+
+  const target = path.resolve(root, relative)
+  if (!isPathInside(target, [root])) return null
+  return target
+}
+
+export function registerAppSchemePrivileges(): void {
+  // Lazy require so resolveAppProtocolPath can be unit-tested without Electron.
+  const { protocol } = require('electron') as typeof import('electron')
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: APP_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        stream: true
+      }
+    }
+  ])
+}
+
+function notFound(): Response {
+  return new Response('Not Found', { status: 404, headers: { 'content-type': 'text/plain' } })
+}
+
+export function registerAppProtocolHandler(): void {
+  const { protocol, net } = require('electron') as typeof import('electron')
+  protocol.handle(APP_SCHEME, async (request) => {
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response(null, { status: 405 })
+    }
+    const origin = request.headers.get('Origin')
+    if (origin && origin !== `${APP_SCHEME}://${APP_HOST}`) {
+      return new Response(null, { status: 403 })
+    }
+    const target = resolveAppProtocolPath(request.url)
+    if (!target) return notFound()
+    try {
+      return await net.fetch(pathToFileURL(target).href)
+    } catch {
+      return notFound()
+    }
+  })
+}

--- a/src/main/guest-webview.ts
+++ b/src/main/guest-webview.ts
@@ -1,0 +1,49 @@
+import { app } from 'electron'
+import { join } from 'path'
+
+const CONTENT_PRELOAD_SUFFIX = join('preload', 'content-preload.js').replace(/\\/g, '/')
+
+function isAllowedGuestSrc(src: string | undefined): boolean {
+  if (!src) return false
+  try {
+    const url = new URL(src)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function isContentPreload(preload: string | undefined): boolean {
+  if (!preload) return false
+  return preload.replace(/\\/g, '/').endsWith(CONTENT_PRELOAD_SUFFIX)
+}
+
+/**
+ * Force safe webPreferences on every <webview> attach. Guests load
+ * user-supplied Open WebUI origins and must never gain Node or an
+ * unexpected preload.
+ *
+ * `will-attach-webview` is a WebContents event (not app). Listen on
+ * every contents via `web-contents-created`.
+ */
+export function registerGuestWebviewPolicy(): void {
+  app.on('web-contents-created', (_event, contents) => {
+    contents.on('will-attach-webview', (event, webPreferences, params) => {
+      webPreferences.nodeIntegration = false
+      webPreferences.nodeIntegrationInWorker = false
+      webPreferences.nodeIntegrationInSubFrames = false
+      webPreferences.contextIsolation = true
+      webPreferences.sandbox = true
+      webPreferences.webSecurity = true
+      webPreferences.allowRunningInsecureContent = false
+
+      if (!isContentPreload(webPreferences.preload)) {
+        delete webPreferences.preload
+      }
+
+      if (!isAllowedGuestSrc(params.src)) {
+        event.preventDefault()
+      }
+    })
+  })
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 
 import {
   app,
@@ -15,7 +14,8 @@ import {
   Menu,
   ipcMain,
   Tray,
-  dialog
+  dialog,
+  type MenuItemConstructorOptions
 } from 'electron'
 import path, { join } from 'path'
 import { readFile, statfs } from 'fs/promises'
@@ -44,7 +44,6 @@ import {
   setConfig,
   startServer,
   stopAllServers,
-  uninstallPython,
   validateRemoteUrl,
   type AppConfig,
   type Connection
@@ -83,6 +82,22 @@ import {
 } from './utils/huggingface'
 
 import { initUpdater, checkForUpdates, downloadUpdate, installUpdate } from './updater'
+import { registerGuestWebviewPolicy } from './guest-webview'
+import { registerCertificatePolicy } from './tls'
+import { isPathInside } from './safe-open'
+import { linuxNeedsNoSandbox } from './linux-sandbox'
+import {
+  registerAppProtocolHandler,
+  registerAppSchemePrivileges,
+  shellPageUrl
+} from './app-protocol'
+import { errorMessage } from './utils/error-message'
+import {
+  isAccessCallbackUrl,
+  loggableUrl,
+  originOf,
+  shouldOpenInSystemBrowser
+} from './webview-navigation'
 
 import log from 'electron-log'
 log.transports.file.resolvePathFn = () => getLogFilePath('main')
@@ -92,7 +107,12 @@ import icon from '../../resources/icon.png?asset'
 import { existsSync, writeFileSync, unlinkSync } from 'fs'
 
 if (process.platform === 'linux') {
-  app.commandLine.appendSwitch('no-sandbox')
+  // AppImage / snap / Flatpak cannot use Chromium's SUID sandbox. Unpackaged
+  // `electron` (npm run dev) ships chrome-sandbox without the setuid bit.
+  // Native .deb / .rpm keep the renderer sandbox.
+  if (linuxNeedsNoSandbox(process.env, app.isPackaged)) {
+    app.commandLine.appendSwitch('no-sandbox')
+  }
 
   // Work around /dev/shm access failures in AppImage and other containerised
   // environments.  AppImage's FUSE mount can restrict child-process access to
@@ -121,9 +141,8 @@ if (process.platform === 'linux') {
   app.commandLine.appendSwitch('use-gl', 'angle')
   app.commandLine.appendSwitch('use-angle', 'swiftshader')
 
-  // Disable the GPU sandbox — the sandbox setup triggers shared-memory
-  // allocation failures in /dev/shm.  The browser process is already
-  // un-sandboxed (--no-sandbox above).
+  // GPU-process sandbox only. Separate from Chromium's renderer sandbox;
+  // kept on Linux because GPU sandbox setup still trips /dev/shm failures.
   app.commandLine.appendSwitch('disable-gpu-sandbox')
 }
 
@@ -146,6 +165,9 @@ if (gpuSandboxDisabled) {
 // repeated GPU process crashes within the same session.
 app.disableDomainBlockingFor3DAPIs()
 
+// Custom protocol for the packaged Svelte shell. Must run before ready.
+registerAppSchemePrivileges()
+
 // ─── State ──────────────────────────────────────────────
 
 let mainWindow: BrowserWindow | null = null
@@ -154,6 +176,7 @@ let spotlightWindow: BrowserWindow | null = null
 let voiceInputWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let isQuiting = false
+let quittingCleanedUp = false
 
 let CONFIG: AppConfig | null = null
 let SERVER_URL: string | null = null
@@ -306,21 +329,22 @@ function createSpotlightWindow(): BrowserWindow {
     hasShadow: false,
     show: false,
     focusable: true,
-    // Ensure the window appears on whichever Space/desktop the user is
-    // currently on, rather than pulling them back to the primary Space.
-    visibleOnAllWorkspaces: true,
     icon: path.join(__dirname, 'assets/icon.png'),
     webPreferences: {
       preload: join(__dirname, '../preload/spotlight-preload.js'),
-      sandbox: false,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
       webviewTag: false
     }
   })
+  // Keep Spotlight on the current Space instead of stealing the primary desktop.
+  spotlightWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
 
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     spotlightWindow.loadURL(`${process.env['ELECTRON_RENDERER_URL']}/spotlight.html`)
   } else {
-    spotlightWindow.loadFile(join(__dirname, '../renderer/spotlight.html'))
+    spotlightWindow.loadURL(shellPageUrl('spotlight.html'))
   }
 
   // Hide on blur — but only when the window was truly visible and settled.
@@ -419,7 +443,9 @@ function createVoiceInputWindow(): BrowserWindow {
     icon: path.join(__dirname, 'assets/icon.png'),
     webPreferences: {
       preload: join(__dirname, '../preload/voice-input-preload.js'),
-      sandbox: false,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
       webviewTag: false,
       autoplayPolicy: 'no-user-gesture-required'
     }
@@ -435,7 +461,7 @@ function createVoiceInputWindow(): BrowserWindow {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     voiceInputWindow.loadURL(`${process.env['ELECTRON_RENDERER_URL']}/voice-input.html`)
   } else {
-    voiceInputWindow.loadFile(join(__dirname, '../renderer/voice-input.html'))
+    voiceInputWindow.loadURL(shellPageUrl('voice-input.html'))
   }
 
   voiceInputWindow.on('closed', () => {
@@ -461,7 +487,7 @@ function playChime(ascending: boolean): Promise<void> {
     if (!exists) { resolve(); return }
 
     if (process.platform === 'darwin') {
-      execFile('afplay', [soundPath], (err, stdout, stderr) => {
+      execFile('afplay', [soundPath], (err, _stdout, stderr) => {
         if (err) log.warn('afplay error:', err.message, stderr)
         resolve()
       })
@@ -636,7 +662,9 @@ function createMainWindow(show = true): void {
     ...(process.platform !== 'darwin' ? { titleBarOverlay: true } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
-      sandbox: false,
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
       webviewTag: true
     }
   }
@@ -673,7 +701,7 @@ function createMainWindow(show = true): void {
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
     mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    mainWindow.loadURL(shellPageUrl('index.html'))
   }
 
   // ── Persist window bounds on geometry changes ──
@@ -700,7 +728,7 @@ function createMainWindow(show = true): void {
   })
 }
 
-function createContentWindow(url: string, connectionId: string): BrowserWindow {
+export function createContentWindow(url: string, connectionId: string): BrowserWindow {
   if (contentWindow && !contentWindow.isDestroyed()) {
     contentWindow.loadURL(url)
     contentWindow.show()
@@ -769,10 +797,11 @@ function createContentWindow(url: string, connectionId: string): BrowserWindow {
 
 const updateTray = () => {
   if (!tray || !CONFIG) return
+  const cfg = CONFIG
 
   // Remote connections from config
-  const remoteItems = (CONFIG.connections || []).map((conn) => ({
-    label: `${conn.id === CONFIG.defaultConnectionId ? '★ ' : ''}${conn.name}`,
+  const remoteItems = (cfg.connections || []).map((conn) => ({
+    label: `${conn.id === cfg.defaultConnectionId ? '★ ' : ''}${conn.name}`,
     sublabel: conn.url,
     click: async () => {
       const result = await connectTo(conn)
@@ -783,8 +812,8 @@ const updateTray = () => {
   // Virtual local connection (when package is installed)
   const localItem = isPackageInstalled('open-webui')
     ? [{
-        label: `${CONFIG.defaultConnectionId === 'local' ? '★ ' : ''}Open WebUI (Local)`,
-        sublabel: SERVER_URL || `http://127.0.0.1:${CONFIG.localServer?.port ?? 8080}`,
+        label: `${cfg.defaultConnectionId === 'local' ? '★ ' : ''}Open WebUI (Local)`,
+        sublabel: SERVER_URL || `http://127.0.0.1:${cfg.localServer?.port ?? 8080}`,
         click: async () => {
           const result = await connectTo(buildLocalConnection())
           if (result) sendToRenderer('connection:open', result)
@@ -824,15 +853,14 @@ const updateTray = () => {
     {
       label: 'Quit Open WebUI',
       accelerator: 'CommandOrControl+Q',
-      click: async () => {
-        await stopServerHandler()
+      click: () => {
         isQuiting = true
         app.quit()
       }
     }
   ]
 
-  const trayMenu = Menu.buildFromTemplate(trayMenuTemplate)
+  const trayMenu = Menu.buildFromTemplate(trayMenuTemplate as MenuItemConstructorOptions[])
   tray?.setContextMenu(trayMenu)
 }
 
@@ -908,10 +936,6 @@ const connectTo = async (connection: Connection) => {
 
 // ─── Server Lifecycle ───────────────────────────────────
 
-// Active PTY data listener — when a MessagePort is connected, PTY data
-// flows to the port. This disposable gets replaced on each pty:connect.
-let activePtyDataDisposable: { dispose: () => void } | null = null
-
 const startServerHandler = async (): Promise<boolean> => {
   if (SERVER_STATUS === 'starting' || SERVER_STATUS === 'started') {
     log.info('[server] Already running or starting, skipping duplicate start')
@@ -969,7 +993,7 @@ const startServerHandler = async (): Promise<boolean> => {
     log.error('Failed to start server:', error)
     SERVER_STATUS = 'failed'
     sendToRenderer('status:server', SERVER_STATUS)
-    sendToRenderer('error', { message: `Failed to start server: ${error?.message}` })
+    sendToRenderer('error', { message: `Failed to start server: ${errorMessage(error)}` })
     updateTray()
     return false
   }
@@ -1163,14 +1187,19 @@ const resetAppHandler = async () => {
     new Notification({ title: 'Open WebUI', body: 'Application has been reset.' }).show()
   } catch (error) {
     log.error('Failed to reset:', error)
-    new Notification({ title: 'Open WebUI', body: `Reset failed: ${error.message}` }).show()
+    new Notification({ title: 'Open WebUI', body: `Reset failed: ${errorMessage(error)}` }).show()
   }
 }
 
 // ─── Helpers ────────────────────────────────────────────
 
 const sendToRenderer = (type: string, data?: any) => {
-  mainWindow?.webContents.send('main:data', { type, data })
+  if (!mainWindow || mainWindow.isDestroyed()) return
+  try {
+    mainWindow.webContents.send('main:data', { type, data })
+  } catch (error) {
+    log.warn('sendToRenderer skipped (window gone):', error)
+  }
 }
 
 // ─── App Lifecycle ──────────────────────────────────────
@@ -1197,15 +1226,20 @@ if (!gotTheLock) {
   })
 
   app.whenReady().then(async () => {
+    registerAppProtocolHandler()
     CONFIG = await getConfig()
     loadSpotlightPosition()
-    log.info('Config:', CONFIG)
+    log.info(
+      `Config loaded (connections=${CONFIG.connections?.length ?? 0}, default=${CONFIG.defaultConnectionId ?? 'none'})`
+    )
 
     app.name = 'Open WebUI'
     if (process.platform === 'darwin' && app.dock) {
       app.dock.setIcon(icon)
     }
     electronApp.setAppUserModelId('com.openwebui.desktop')
+
+    registerGuestWebviewPolicy()
 
     // ─── GPU Process Crash Recovery ──────────────────
     // If the GPU process exits fatally (e.g. sandbox init failure on
@@ -1244,34 +1278,17 @@ if (!gotTheLock) {
       log.info('Running with GPU sandbox disabled (marker file present)')
     }
 
-    // ─── Self-Signed / Untrusted Certificate Support ─
-    // Allow connections to Open WebUI instances that use self-signed or
-    // otherwise untrusted SSL certificates (issue #108). The user
-    // explicitly configures the server URL, so trusting all certs is
-    // acceptable — this matches the behaviour of VS Code, Postman, and
-    // other Electron apps used in enterprise/self-hosted environments.
-    app.on('certificate-error', (event, _webContents, url, error, certificate, callback) => {
-      log.warn(
-        `Certificate error: ${error} for ${url} ` +
-        `(subject: ${certificate.subjectName}, issuer: ${certificate.issuerName})`
-      )
-      event.preventDefault()
-      callback(true)
+    // Self-signed Open WebUI servers (#108): allow cert errors only for
+    // origins the user added as connections, plus loopback. GitHub,
+    // Hugging Face, and auto-update keep default PKI.
+    registerCertificatePolicy(() => {
+      const urls = (CONFIG?.connections ?? []).map((c) => c.url)
+      if (SERVER_URL) urls.push(SERVER_URL)
+      return urls
     })
 
-    // Trust all certs on the default session (used by net.fetch() in
-    // validateRemoteUrl / checkUrlAndOpen).
-    session.defaultSession.setCertificateVerifyProc((_request, callback) => {
-      callback(0) // 0 = verified/trusted
-    })
-
-    // Webviews use partitioned sessions (persist:connection-*). Each
-    // new partition's session also needs to trust all certs.
+    // Webviews use partitioned sessions (persist:connection-*).
     app.on('session-created', (newSession) => {
-      newSession.setCertificateVerifyProc((_request, callback) => {
-        callback(0)
-      })
-
       // Grant media / notification permissions for webview partition sessions
       // so that auth flows, media capture, and notifications work correctly.
       newSession.setPermissionRequestHandler((_webContents, permission, callback) => {
@@ -1301,6 +1318,155 @@ if (!gotTheLock) {
     // For webview guests we also intercept navigation and popup events
     // so that external links open in the user's default browser instead
     // of navigating the webview or spawning a new Electron window (#165).
+    const partitionBySession = new WeakMap<Electron.Session, string>()
+    const hookedGuests = new WeakSet<Electron.WebContents>()
+
+    const hookGuestNavigation = (guest: Electron.WebContents): void => {
+      if (hookedGuests.has(guest) || guest.isDestroyed()) return
+      hookedGuests.add(guest)
+
+      const homeUrlFor = (): string | null => {
+        const partition = partitionBySession.get(guest.session) ?? ''
+        const prefix = 'persist:connection-'
+        if (!partition.startsWith(prefix)) return null
+        const id = partition.slice(prefix.length)
+        if (id === 'local') {
+          return SERVER_URL || `http://127.0.0.1:${CONFIG?.localServer?.port ?? 8080}`
+        }
+        return CONFIG?.connections?.find((c) => c.id === id)?.url ?? null
+      }
+
+      const homeOriginFor = (): string | null => {
+        const home = homeUrlFor()
+        return home ? originOf(home) : null
+      }
+
+      const bounceToOs = (targetUrl: string): boolean =>
+        shouldOpenInSystemBrowser({
+          currentUrl: guest.getURL(),
+          targetUrl,
+          homeOrigin: homeOriginFor()
+        })
+
+      const returnGuestHome = (reason: string): void => {
+        const home = homeUrlFor()
+        if (!home || guest.isDestroyed()) return
+        if (originOf(guest.getURL()) === originOf(home)) {
+          guest.reload()
+          return
+        }
+        log.info(`webview ${reason}; loading home ${loggableUrl(home)}`)
+        guest.loadURL(home)
+      }
+
+      // Chat target=_blank → OS browser (#165). Auth popups must share the
+      // guest session and keep the Access opener alive (#39, #44).
+      guest.setWindowOpenHandler(({ url }) => {
+        if (bounceToOs(url)) {
+          log.info('webview popup → OS browser:', loggableUrl(url))
+          openUrl(url)
+          return { action: 'deny' }
+        }
+        log.info('webview popup → auth window:', loggableUrl(url))
+        return {
+          action: 'allow',
+          overrideBrowserWindowOptions: {
+            width: 560,
+            height: 780,
+            autoHideMenuBar: true,
+            webPreferences: {
+              sandbox: true,
+              nodeIntegration: false,
+              contextIsolation: true,
+              session: guest.session
+            }
+          }
+        }
+      })
+
+      guest.on('did-create-window', (win) => {
+        win.on('closed', () => {
+          returnGuestHome('auth window closed')
+        })
+      })
+
+      guest.on('will-navigate', (details) => {
+        if (details.isMainFrame === false) return
+        if (bounceToOs(details.url)) {
+          log.info('webview navigate → OS browser:', loggableUrl(details.url))
+          details.preventDefault()
+          openUrl(details.url)
+        }
+      })
+
+      guest.on('did-navigate', (_event, url) => {
+        log.info('webview navigated:', loggableUrl(url))
+        if (isAccessCallbackUrl(url)) {
+          returnGuestHome('Access callback')
+        }
+      })
+
+      guest.on('did-fail-load', (_event, code, desc, url, isMainFrame) => {
+        if (!isMainFrame || code === -3) return
+        log.warn(`webview fail-load ${code} ${desc} ${loggableUrl(url)}`)
+      })
+
+      // ── Native right-click context menu (#161) ──────────────────
+      // Electron <webview> guests don't show a context menu by default,
+      // which blocks right-click → Paste / Autofill / password-manager
+      // integration on login pages.  Build a native menu with standard
+      // editing actions, spell-check suggestions, and link handling.
+      guest.on('context-menu', (_event, params) => {
+        const menuItems: Electron.MenuItemConstructorOptions[] = []
+
+        if (params.misspelledWord && params.dictionarySuggestions?.length) {
+          for (const suggestion of params.dictionarySuggestions) {
+            menuItems.push({
+              label: suggestion,
+              click: () => guest.replaceMisspelling(suggestion)
+            })
+          }
+          menuItems.push({ type: 'separator' })
+        }
+
+        if (params.linkURL) {
+          const external = bounceToOs(params.linkURL)
+          menuItems.push({
+            label: external ? 'Open Link in Browser' : 'Open Link',
+            click: () => {
+              if (external) openUrl(params.linkURL)
+              else guest.loadURL(params.linkURL)
+            }
+          })
+          menuItems.push({
+            label: 'Copy Link',
+            click: () => clipboard.writeText(params.linkURL)
+          })
+          menuItems.push({ type: 'separator' })
+        }
+
+        if (params.isEditable) {
+          menuItems.push(
+            { label: 'Undo', role: 'undo', enabled: params.editFlags.canUndo },
+            { label: 'Redo', role: 'redo', enabled: params.editFlags.canRedo },
+            { type: 'separator' },
+            { label: 'Cut', role: 'cut', enabled: params.editFlags.canCut },
+            { label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy },
+            { label: 'Paste', role: 'paste', enabled: params.editFlags.canPaste },
+            { label: 'Select All', role: 'selectAll', enabled: params.editFlags.canSelectAll }
+          )
+        } else if (params.selectionText) {
+          menuItems.push(
+            { label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy }
+          )
+        }
+
+        if (menuItems.length > 0) {
+          Menu.buildFromTemplate(menuItems).popup()
+        }
+      })
+    }
+
     app.on('web-contents-created', (_event, contents) => {
       contents.on('render-process-gone', (_e, details) => {
         if (details.reason !== 'clean-exit') {
@@ -1311,83 +1477,19 @@ if (!gotTheLock) {
         }
       })
 
+      contents.on('will-attach-webview', (_e, _prefs, params) => {
+        if (params.partition) {
+          partitionBySession.set(session.fromPartition(params.partition), params.partition)
+        }
+      })
+
+      // Guest WebContents: hook both creation and attach. Attach is the
+      // reliable Electron event; type==='webview' can race.
+      contents.on('did-attach-webview', (_e, guest) => {
+        hookGuestNavigation(guest)
+      })
       if (contents.getType() === 'webview') {
-        // ── Popups (target="_blank" links) → open in default browser ──
-        contents.setWindowOpenHandler(({ url }) => {
-          openUrl(url)
-          return { action: 'deny' }
-        })
-
-        // ── In-page navigation to a different origin → open externally ──
-        // This catches regular link clicks (no target) that would navigate
-        // the webview away from the Open WebUI instance.
-        contents.on('will-navigate', (event, url) => {
-          try {
-            const currentOrigin = new URL(contents.getURL()).origin
-            const targetOrigin = new URL(url).origin
-            if (targetOrigin !== currentOrigin) {
-              event.preventDefault()
-              openUrl(url)
-            }
-          } catch {
-            // Malformed URL — let it through so Chromium can handle/reject it
-          }
-        })
-
-        // ── Native right-click context menu (#161) ──────────────────
-        // Electron <webview> guests don't show a context menu by default,
-        // which blocks right-click → Paste / Autofill / password-manager
-        // integration on login pages.  Build a native menu with standard
-        // editing actions, spell-check suggestions, and link handling.
-        contents.on('context-menu', (_event, params) => {
-          const menuItems: Electron.MenuItemConstructorOptions[] = []
-
-          // Spell-check suggestions (if any)
-          if (params.misspelledWord && params.dictionarySuggestions?.length) {
-            for (const suggestion of params.dictionarySuggestions) {
-              menuItems.push({
-                label: suggestion,
-                click: () => contents.replaceMisspelling(suggestion)
-              })
-            }
-            menuItems.push({ type: 'separator' })
-          }
-
-          // Link handling
-          if (params.linkURL) {
-            menuItems.push({
-              label: 'Open Link in Browser',
-              click: () => openUrl(params.linkURL)
-            })
-            menuItems.push({
-              label: 'Copy Link',
-              click: () => clipboard.writeText(params.linkURL)
-            })
-            menuItems.push({ type: 'separator' })
-          }
-
-          // Editable field actions (input, textarea, contenteditable)
-          if (params.isEditable) {
-            menuItems.push(
-              { label: 'Undo', role: 'undo', enabled: params.editFlags.canUndo },
-              { label: 'Redo', role: 'redo', enabled: params.editFlags.canRedo },
-              { type: 'separator' },
-              { label: 'Cut', role: 'cut', enabled: params.editFlags.canCut },
-              { label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy },
-              { label: 'Paste', role: 'paste', enabled: params.editFlags.canPaste },
-              { label: 'Select All', role: 'selectAll', enabled: params.editFlags.canSelectAll }
-            )
-          } else if (params.selectionText) {
-            // Non-editable text selection
-            menuItems.push(
-              { label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy }
-            )
-          }
-
-          if (menuItems.length > 0) {
-            Menu.buildFromTemplate(menuItems).popup()
-          }
-        })
+        hookGuestNavigation(contents)
       }
     })
 
@@ -1401,6 +1503,10 @@ if (!gotTheLock) {
       arch: process.arch,
       username: require('os').userInfo().username,
       gpuSandboxDisabled
+    }))
+
+    ipcMain.handle('window:isFocused', () => ({
+      isFocused: !!(mainWindow && !mainWindow.isDestroyed() && mainWindow.isFocused())
     }))
 
     ipcMain.handle('app:contentPreloadPath', () => {
@@ -1445,7 +1551,7 @@ if (!gotTheLock) {
         return res
       } catch (error) {
         sendToRenderer('status:python', false)
-        sendToRenderer('error', { message: error?.message ?? 'Python installation failed. Please check your internet connection and try again.' })
+        sendToRenderer('error', { message: errorMessage(error) || 'Python installation failed. Please check your internet connection and try again.' })
         return false
       }
     })
@@ -1487,7 +1593,7 @@ if (!gotTheLock) {
         return true
       } catch (error) {
         sendToRenderer('status:package', false)
-        sendToRenderer('error', { message: error?.message ?? 'Package installation failed. Please check your internet connection and try again.' })
+        sendToRenderer('error', { message: errorMessage(error) || 'Package installation failed. Please check your internet connection and try again.' })
         return false
       }
     })
@@ -1813,11 +1919,11 @@ if (!gotTheLock) {
 
         const result = await response.json()
         return result
-      } catch (error: any) {
+      } catch (error) {
         log.error('voiceInput:transcribe failed:', error)
         new Notification({
           title: 'Voice Input Failed',
-          body: error?.message || 'Transcription failed. Check logs for details.'
+          body: errorMessage(error) || 'Transcription failed. Check logs for details.'
         }).show()
         throw error
       }
@@ -1888,7 +1994,7 @@ if (!gotTheLock) {
       } catch (error) {
         log.error('Failed to start Open Terminal:', error)
         sendToRenderer('status:open-terminal', 'failed')
-        sendToRenderer('error', { message: `Open Terminal failed: ${error?.message}` })
+        sendToRenderer('error', { message: `Open Terminal failed: ${errorMessage(error)}` })
         return null
       }
     })
@@ -1929,7 +2035,7 @@ if (!gotTheLock) {
       } catch (error) {
         log.error('Failed to setup llamacpp:', error)
         sendToRenderer('status:llamacpp', 'failed')
-        sendToRenderer('error', { message: `llamacpp setup failed: ${error?.message}` })
+        sendToRenderer('error', { message: `llamacpp setup failed: ${errorMessage(error)}` })
         return null
       }
     })
@@ -1957,7 +2063,7 @@ if (!gotTheLock) {
       } catch (error) {
         log.error('Failed to start llamacpp:', error)
         sendToRenderer('status:llamacpp', 'failed')
-        sendToRenderer('error', { message: `llamacpp failed: ${error?.message}` })
+        sendToRenderer('error', { message: `llamacpp failed: ${errorMessage(error)}` })
         return null
       }
     })
@@ -2001,7 +2107,9 @@ if (!gotTheLock) {
           })
           setTimeout(() => sendToRenderer('models:refresh'), 500)
         }
-        await setConfig({ llamaCpp: { ...CONFIG?.llamaCpp, enabled: false } })
+        if (CONFIG?.llamaCpp) {
+          await setConfig({ llamaCpp: { ...CONFIG.llamaCpp, enabled: false } })
+        }
         CONFIG = await getConfig()
         return true
       } catch (error) {
@@ -2042,8 +2150,8 @@ if (!gotTheLock) {
         return filepath
       } catch (error) {
         log.error('Failed to download model:', error)
-        sendToRenderer('status:huggingface-download', { repo, filename, status: 'failed', error: error?.message })
-        sendToRenderer('error', { message: `Model download failed: ${error?.message}` })
+        sendToRenderer('status:huggingface-download', { repo, filename, status: 'failed', error: errorMessage(error) })
+        sendToRenderer('error', { message: `Model download failed: ${errorMessage(error)}` })
         return null
       }
     })
@@ -2084,7 +2192,11 @@ if (!gotTheLock) {
 
     ipcMain.handle('open:path', async (_event, folderPath: string) => {
       if (!folderPath) throw new Error('No path provided')
-      await shell.openPath(folderPath)
+      const allowedRoots = [getUserDataPath(), getInstallDir()]
+      if (!isPathInside(folderPath, allowedRoots)) {
+        throw new Error('Blocked opening a path outside app directories')
+      }
+      await shell.openPath(path.resolve(folderPath))
     })
 
     ipcMain.handle('notification', async (_event, { title, body }) => {
@@ -2111,7 +2223,7 @@ if (!gotTheLock) {
       } catch (error) {
         log.error('Failed to update llamacpp:', error)
         sendToRenderer('status:llamacpp', 'failed')
-        sendToRenderer('error', { message: `llamacpp update failed: ${error?.message}` })
+        sendToRenderer('error', { message: `llamacpp update failed: ${errorMessage(error)}` })
         throw error
       }
     })
@@ -2131,7 +2243,7 @@ if (!gotTheLock) {
 
     // Enable screen capture
     session.defaultSession.setDisplayMediaRequestHandler(
-      (request, callback) => {
+      (_request, callback) => {
         desktopCapturer.getSources({ types: ['screen'] }).then((sources) => {
           callback({ video: sources[0], audio: 'loopback' })
         })
@@ -2209,28 +2321,48 @@ if (!gotTheLock) {
   })
 
   app.on('window-all-closed', () => {
+    if (isQuiting) return
+    if (CONFIG?.runInBackground) return
     if (process.platform !== 'darwin') {
       app.quit()
     }
   })
 
-  app.on('before-quit', async () => {
+  app.on('will-quit', (event) => {
+    if (quittingCleanedUp) return
+    event.preventDefault()
     isQuiting = true
-    await stopLlamaCpp()
-    await stopOpenTerminal()
-    await stopServerHandler()
-    globalShortcut.unregisterAll()
-    mainWindow = null
-    contentWindow = null
-    if (spotlightWindow && !spotlightWindow.isDestroyed()) {
-      spotlightWindow.destroy()
-    }
-    spotlightWindow = null
-    if (voiceInputWindow && !voiceInputWindow.isDestroyed()) {
-      voiceInputWindow.destroy()
-    }
-    voiceInputWindow = null
-    tray?.destroy()
-    tray = null
+    const forceExit = setTimeout(() => {
+      log.warn('Quit cleanup timed out; exiting')
+      quittingCleanedUp = true
+      app.exit(0)
+    }, 8000)
+    void (async () => {
+      try {
+        await stopLlamaCpp()
+        await stopOpenTerminal()
+        await stopServerHandler()
+      } catch (error) {
+        log.warn('Error while stopping child processes on quit:', error)
+      } finally {
+        clearTimeout(forceExit)
+        globalShortcut.unregisterAll()
+        if (mainWindow && !mainWindow.isDestroyed()) mainWindow.destroy()
+        mainWindow = null
+        contentWindow = null
+        if (spotlightWindow && !spotlightWindow.isDestroyed()) {
+          spotlightWindow.destroy()
+        }
+        spotlightWindow = null
+        if (voiceInputWindow && !voiceInputWindow.isDestroyed()) {
+          voiceInputWindow.destroy()
+        }
+        voiceInputWindow = null
+        tray?.destroy()
+        tray = null
+        quittingCleanedUp = true
+        app.exit(0)
+      }
+    })()
   })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -92,6 +92,7 @@ import {
   shellPageUrl
 } from './app-protocol'
 import { errorMessage } from './utils/error-message'
+import { safePtyResize, safePtyWrite } from './utils/safe-pty'
 import {
   isAccessCallbackUrl,
   loggableUrl,
@@ -1053,9 +1054,13 @@ const connectPtyPort = (pid?: number): void => {
     port1.on('message', (event) => {
       const msg = event.data
       if (msg.type === 'input') {
-        ptyProcess.write(msg.data)
+        if (!safePtyWrite(ptyProcess, msg.data)) {
+          log.warn('pty write ignored — process already exited')
+        }
       } else if (msg.type === 'resize') {
-        ptyProcess.resize(msg.cols, msg.rows)
+        if (!safePtyResize(ptyProcess, msg.cols, msg.rows)) {
+          log.warn('pty resize ignored — process already exited')
+        }
       }
     })
     port1.start()

--- a/src/main/linux-sandbox.ts
+++ b/src/main/linux-sandbox.ts
@@ -1,0 +1,17 @@
+/**
+ * Chromium's SUID sandbox cannot be set up inside AppImage/snap/Flatpak,
+ * and unpackaged `electron` binaries ship chrome-sandbox without the
+ * setuid bit. Native .deb/.rpm installs can keep the renderer sandbox.
+ */
+export function linuxNeedsNoSandbox(
+  env: NodeJS.ProcessEnv = process.env,
+  packaged = true
+): boolean {
+  if (!packaged) return true
+  return Boolean(
+    env.APPIMAGE ||
+      env.SNAP ||
+      env.FLATPAK_ID ||
+      env.ELECTRON_DISABLE_SANDBOX === '1'
+  )
+}

--- a/src/main/safe-open.ts
+++ b/src/main/safe-open.ts
@@ -1,0 +1,39 @@
+import path from 'path'
+
+const ALLOWED_SCHEMES = new Set(['http:', 'https:', 'mailto:'])
+
+export function isAllowedExternalUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return ALLOWED_SCHEMES.has(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
+export function isPathInside(target: string, roots: string[]): boolean {
+  const resolved = path.resolve(target)
+  return roots.some((root) => {
+    const resolvedRoot = path.resolve(root)
+    return resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep)
+  })
+}
+
+export function normalizeOpenUrl(url: string): string {
+  if (url.startsWith('http://0.0.0.0')) {
+    return url.replace('http://0.0.0.0', 'http://localhost')
+  }
+  return url
+}
+
+export async function openExternalUrl(url: string): Promise<void> {
+  if (!url) {
+    throw new Error('No URL provided to open in browser.')
+  }
+  const normalized = normalizeOpenUrl(url)
+  if (!isAllowedExternalUrl(normalized)) {
+    throw new Error('Blocked opening a URL with a disallowed scheme')
+  }
+  const { shell } = await import('electron')
+  await shell.openExternal(normalized)
+}

--- a/src/main/tls.ts
+++ b/src/main/tls.ts
@@ -1,0 +1,58 @@
+import { app } from 'electron'
+import log from 'electron-log'
+
+function hostnameIsLoopback(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '[::1]'
+  )
+}
+
+export function originOf(url: string): string | null {
+  try {
+    return new URL(url).origin
+  } catch {
+    return null
+  }
+}
+
+export function isTrustedInsecureOrigin(url: string, configuredUrls: string[]): boolean {
+  const target = originOf(url)
+  if (!target) return false
+
+  try {
+    if (hostnameIsLoopback(new URL(url).hostname)) return true
+  } catch {
+    return false
+  }
+
+  for (const configured of configuredUrls) {
+    const origin = originOf(configured)
+    if (origin && origin === target) return true
+  }
+  return false
+}
+
+/**
+ * Trust extra certificates only for origins the user added as connections
+ * (and loopback). Default Chromium PKI stays in force for GitHub, HF,
+ * auto-update, and everything else.
+ */
+export function registerCertificatePolicy(getConfiguredUrls: () => string[]): void {
+  app.on('certificate-error', (event, _webContents, url, error, certificate, callback) => {
+    const allow = isTrustedInsecureOrigin(url, getConfiguredUrls())
+    log.warn(
+      `Certificate error: ${error} for ${url} ` +
+        `(subject: ${certificate.subjectName}, issuer: ${certificate.issuerName}) ` +
+        `→ ${allow ? 'allow (configured origin)' : 'reject'}`
+    )
+    if (allow) {
+      event.preventDefault()
+      callback(true)
+    } else {
+      callback(false)
+    }
+  })
+}

--- a/src/main/utils/artifact-integrity.ts
+++ b/src/main/utils/artifact-integrity.ts
@@ -1,0 +1,160 @@
+import { createHash } from 'crypto'
+import {
+  createWriteStream,
+  existsSync,
+  unlinkSync,
+  renameSync,
+  openSync,
+  readSync,
+  closeSync
+} from 'fs'
+import { finished } from 'stream/promises'
+
+/**
+ * SHA-256 of python-build-standalone 20260310 install_only tarballs
+ * (https://github.com/astral-sh/python-build-standalone/releases/tag/20260310 SHA256SUMS).
+ * Only the platform/arch pairs this app actually downloads.
+ */
+export const PYTHON_SHA256: Record<string, string> = {
+  'cpython-3.12.13+20260310-aarch64-apple-darwin-install_only.tar.gz':
+    '58038f6643b0c51385aa8af1549d2f6d9598c7a48383b9c74fc65481b2b5e6d5',
+  'cpython-3.12.13+20260310-aarch64-pc-windows-msvc-install_only.tar.gz':
+    '23a9d18ad7d62e8470f6dfbf3e3ddc8c6a343ec8a07bad0197689f96f024a98f',
+  'cpython-3.12.13+20260310-aarch64-unknown-linux-gnu-install_only.tar.gz':
+    '872bb2d9959bbcba411af08fa57423d586b779c21c7de70890f99e1c59036efc',
+  'cpython-3.12.13+20260310-x86_64-apple-darwin-install_only.tar.gz':
+    '09d7bfb7e2684d746e2d44bd800becfd07c4c672de907340d279409a8bca2d8b',
+  'cpython-3.12.13+20260310-x86_64-pc-windows-msvc-install_only.tar.gz':
+    'b9f9d17a11944c13a3a2798c8b48ec861b2f10710dc345094f567beed4271427',
+  'cpython-3.12.13+20260310-x86_64-unknown-linux-gnu-install_only.tar.gz':
+    'eddc8bf40c7fca5032acd5de4b89e748e17b16cf61918320a0506c7e450a8df3'
+}
+
+const SHA256_HEX = /^[0-9a-f]{64}$/
+
+export function parseGithubDigest(digest: unknown): string {
+  if (typeof digest !== 'string' || !digest.startsWith('sha256:')) {
+    throw new Error('GitHub release asset is missing a sha256 digest')
+  }
+  const hex = digest.slice('sha256:'.length).toLowerCase()
+  if (!SHA256_HEX.test(hex)) {
+    throw new Error(`Invalid GitHub asset digest: ${digest}`)
+  }
+  return hex
+}
+
+/**
+ * Hugging Face Hub `siblings[].lfs.sha256` (from `?blobs=true`).
+ * Do not use `blobId` / git `oid` — those are the LFS pointer, not the GGUF.
+ */
+export function parseHfLfsSha256(lfs: unknown): string {
+  if (!lfs || typeof lfs !== 'object') {
+    throw new Error('Hugging Face file is missing LFS SHA-256')
+  }
+  const sha = (lfs as { sha256?: unknown }).sha256
+  if (typeof sha !== 'string') {
+    throw new Error('Hugging Face file is missing LFS SHA-256')
+  }
+  const hex = sha.toLowerCase()
+  if (!SHA256_HEX.test(hex)) {
+    throw new Error('Hugging Face file is missing LFS SHA-256')
+  }
+  return hex
+}
+
+export function sha256File(filePath: string): string {
+  const hash = createHash('sha256')
+  const fd = openSync(filePath, 'r')
+  try {
+    const buf = Buffer.alloc(1024 * 1024)
+    let n = 0
+    while ((n = readSync(fd, buf, 0, buf.length, null)) > 0) {
+      hash.update(buf.subarray(0, n))
+    }
+    return hash.digest('hex')
+  } finally {
+    closeSync(fd)
+  }
+}
+
+export function assertSha256(filePath: string, expectedHex: string): void {
+  const actual = sha256File(filePath)
+  const expected = expectedHex.toLowerCase()
+  if (actual !== expected) {
+    throw new Error(`Checksum mismatch for ${filePath}: expected ${expected}, got ${actual}`)
+  }
+}
+
+export function fileMatchesSha256(filePath: string, expectedHex: string): boolean {
+  try {
+    return sha256File(filePath) === expectedHex.toLowerCase()
+  } catch {
+    return false
+  }
+}
+
+export async function downloadAndVerifySha256(
+  url: string,
+  destPath: string,
+  expectedHex: string,
+  onProgress?: (percent: number, downloaded: number, total: number) => void,
+  init?: { headers?: Record<string, string>; signal?: AbortSignal }
+): Promise<string> {
+  const expected = expectedHex.toLowerCase()
+  if (!SHA256_HEX.test(expected)) {
+    throw new Error('Refusing to download without a SHA-256 digest')
+  }
+  const tmpPath = destPath + '.tmp'
+  const response = await fetch(url, {
+    headers: init?.headers,
+    signal: init?.signal,
+    redirect: 'follow'
+  })
+  if (!response.ok || !response.body) {
+    throw new Error(`HTTP error! status: ${response.status}`)
+  }
+
+  const totalSize = parseInt(response.headers.get('content-length') ?? '0', 10)
+  const hash = createHash('sha256')
+  const writer = createWriteStream(tmpPath)
+  const reader = response.body.getReader()
+  let downloadedSize = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      hash.update(value)
+      downloadedSize += value.byteLength
+      if (!writer.write(Buffer.from(value))) {
+        await new Promise<void>((resolve) => writer.once('drain', resolve))
+      }
+      if (onProgress && totalSize) {
+        onProgress((downloadedSize / totalSize) * 100, downloadedSize, totalSize)
+      }
+    }
+    writer.end()
+    await finished(writer)
+  } catch (error) {
+    writer.destroy()
+    try {
+      if (existsSync(tmpPath)) unlinkSync(tmpPath)
+    } catch {
+      /* ignore */
+    }
+    throw error
+  }
+
+  const actual = hash.digest('hex')
+  if (actual !== expected) {
+    try {
+      unlinkSync(tmpPath)
+    } catch {
+      /* ignore */
+    }
+    throw new Error(`Checksum mismatch: expected ${expected}, got ${actual}`)
+  }
+
+  renameSync(tmpPath, destPath)
+  return destPath
+}

--- a/src/main/utils/child-env.ts
+++ b/src/main/utils/child-env.ts
@@ -1,0 +1,64 @@
+/**
+ * Environment keys that must never reach Open WebUI / Open Terminal / llama-server
+ * child processes. Matching is case-insensitive (Windows env is).
+ *
+ * LD_LIBRARY_PATH is intentionally allowed — CUDA/ROCm llama.cpp builds need it.
+ */
+const BLOCKED_ENV = new Set([
+  'LD_PRELOAD',
+  'LD_AUDIT',
+  'DYLD_INSERT_LIBRARIES',
+  'DYLD_LIBRARY_PATH',
+  'DYLD_FRAMEWORK_PATH',
+  'DYLD_FORCE_FLAT_NAMESPACE',
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'ELECTRON_RUN_AS_NODE',
+  'ELECTRON_NO_ASAR',
+  'PYTHONINSPECT',
+  'PYTHONSTARTUP',
+  'PYTHONHOME'
+])
+
+const STRIPPED_LLAMA_FLAGS = new Set(['--host', '--port', '--models-dir'])
+
+export function isBlockedEnvKey(name: string): boolean {
+  return BLOCKED_ENV.has(name.toUpperCase())
+}
+
+export function sanitizeChildEnv(
+  extra: Record<string, string | undefined> = {},
+  base: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(base)) {
+    if (value == null || isBlockedEnvKey(key)) continue
+    out[key] = value
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    if (value == null || isBlockedEnvKey(key)) continue
+    out[key] = value
+  }
+  return out
+}
+
+/**
+ * Drop flags that would override bind address, port, or models directory.
+ * `--host` / `--port` / `--models-dir` are always supplied by the desktop.
+ */
+export function sanitizeLlamaExtraArgs(extraArgs: unknown): string[] {
+  if (!Array.isArray(extraArgs)) return []
+  const out: string[] = []
+  for (let i = 0; i < extraArgs.length; i++) {
+    const arg = extraArgs[i]
+    if (typeof arg !== 'string' || arg.length === 0) continue
+    const eq = arg.indexOf('=')
+    const flag = eq === -1 ? arg : arg.slice(0, eq)
+    if (STRIPPED_LLAMA_FLAGS.has(flag)) {
+      if (eq === -1) i++
+      continue
+    }
+    out.push(arg)
+  }
+  return out
+}

--- a/src/main/utils/error-message.ts
+++ b/src/main/utils/error-message.ts
@@ -1,0 +1,4 @@
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message
+  return String(error)
+}

--- a/src/main/utils/hf-paths.ts
+++ b/src/main/utils/hf-paths.ts
@@ -1,0 +1,63 @@
+import path from 'path'
+
+const REPO_RE = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/
+const FILE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/
+
+export function assertSafeRepo(repo: string): string {
+  if (typeof repo !== 'string' || !REPO_RE.test(repo)) {
+    throw new Error('Invalid Hugging Face repository id')
+  }
+  return repo
+}
+
+export function assertSafeFilename(filename: string): string {
+  if (typeof filename !== 'string' || filename.length === 0) {
+    throw new Error('Invalid model filename')
+  }
+  if (path.isAbsolute(filename) || filename.includes('\0')) {
+    throw new Error('Invalid model filename')
+  }
+  const parts = filename.split(/[/\\]/)
+  if (
+    parts.some(
+      (part) => part === '' || part === '.' || part === '..' || !FILE_SEGMENT_RE.test(part)
+    )
+  ) {
+    throw new Error('Invalid model filename')
+  }
+  if (!filename.toLowerCase().endsWith('.gguf')) {
+    throw new Error('Only GGUF files can be downloaded')
+  }
+  return filename
+}
+
+export function repoSlug(repo: string): string {
+  return assertSafeRepo(repo).replace(/\//g, '--')
+}
+
+export function confinedModelPath(cacheRoot: string, repo: string, filename: string): string {
+  const safeRepo = assertSafeRepo(repo)
+  const safeFile = assertSafeFilename(filename)
+  const resolvedRoot = path.resolve(cacheRoot)
+  const dest = path.resolve(resolvedRoot, repoSlug(safeRepo), safeFile)
+  if (dest !== resolvedRoot && !dest.startsWith(resolvedRoot + path.sep)) {
+    throw new Error('Refusing path outside the models directory')
+  }
+  return dest
+}
+
+export function huggingfaceDownloadUrl(repo: string, filename: string): string {
+  const [owner, name] = assertSafeRepo(repo).split('/')
+  const filePath = assertSafeFilename(filename)
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+  return `https://huggingface.co/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/resolve/main/${filePath}`
+}
+
+export function huggingfaceRepoApiUrl(repo: string): string {
+  const [owner, name] = assertSafeRepo(repo).split('/')
+  // blobs=true is required for siblings[].lfs.sha256 (the GGUF content hash).
+  // Without it the Hub only returns rfilename.
+  return `https://huggingface.co/api/models/${encodeURIComponent(owner)}/${encodeURIComponent(name)}?blobs=true`
+}

--- a/src/main/utils/huggingface.ts
+++ b/src/main/utils/huggingface.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 
 /**
  * Reusable Hugging Face utility module.
@@ -12,7 +11,18 @@ import * as fs from 'fs'
 import * as path from 'path'
 import log from 'electron-log'
 
-import { getInstallDir, downloadFileWithProgress } from './index'
+import { getInstallDir } from './index'
+import {
+  confinedModelPath,
+  huggingfaceDownloadUrl,
+  huggingfaceRepoApiUrl,
+  assertSafeFilename
+} from './hf-paths'
+import {
+  parseHfLfsSha256,
+  fileMatchesSha256,
+  downloadAndVerifySha256
+} from './artifact-integrity'
 
 // ─── Types ──────────────────────────────────────────────
 
@@ -22,6 +32,7 @@ export interface HfModel {
   filepath: string
   size: number        // bytes
   downloadedAt: string // ISO date
+  sha256?: string
 }
 
 export interface HfDownloadProgress {
@@ -66,8 +77,6 @@ const getHfCacheDir = (): string => {
 
   return dir
 }
-
-const repoSlug = (repo: string): string => repo.replace(/\//g, '--')
 
 const getManifestPath = (): string => path.join(getHfCacheDir(), 'manifest.json')
 
@@ -148,98 +157,71 @@ export const downloadModel = async (
   filename: string,
   onProgress?: (progress: HfDownloadProgress) => void,
   token?: string,
-  expectedSize?: number
+  _expectedSize?: number
 ): Promise<string> => {
-  const slug = repoSlug(repo)
-  const repoDir = path.join(getHfCacheDir(), slug)
+  const destPath = confinedModelPath(getHfCacheDir(), repo, filename)
+  const repoDir = path.dirname(destPath)
   if (!fs.existsSync(repoDir)) {
     fs.mkdirSync(repoDir, { recursive: true })
   }
 
-  const destPath = path.join(repoDir, filename)
+  const expectedSha256 = await fetchHfGgufSha256(repo, filename, token)
 
-  // Already downloaded?
   if (fs.existsSync(destPath)) {
-    log.info(`[huggingface] Already cached: ${destPath}`)
-    return destPath
+    if (fileMatchesSha256(destPath, expectedSha256)) {
+      log.info(`[huggingface] Using verified cache: ${repo}/${filename}`)
+      recordManifest(repo, filename, destPath, expectedSha256)
+      return destPath
+    }
+    log.warn(`[huggingface] Cached GGUF failed SHA-256; re-downloading ${repo}/${filename}`)
+    try {
+      fs.unlinkSync(destPath)
+    } catch {
+      /* ignore */
+    }
   }
 
-  // Build download URL
-  const downloadUrl = `https://huggingface.co/${repo}/resolve/main/${encodeURIComponent(filename)}`
-
+  const downloadUrl = huggingfaceDownloadUrl(repo, filename)
   log.info(`[huggingface] Downloading ${repo}/${filename}`)
-  log.info(`[huggingface] URL: ${downloadUrl}`)
 
-  // Download with progress
   const headers: Record<string, string> = {}
   if (token) {
     headers['Authorization'] = `Bearer ${token}`
   }
 
   const key = downloadKey(repo, filename)
-  // Cancel any existing download for the same file
   activeDownloads.get(key)?.abort()
 
   const abortController = new AbortController()
   activeDownloads.set(key, abortController)
-  const { signal } = abortController
-
-  // Use fetch for streaming download with progress
-  const response = await fetch(downloadUrl, {
-    headers,
-    redirect: 'follow',
-    signal
-  })
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to download ${repo}/${filename}: ${response.status} ${response.statusText}`
-    )
-  }
-
-  const contentLength = parseInt(response.headers.get('content-length') ?? '0', 10)
-  const totalBytes = contentLength || expectedSize || 0
-  const reader = response.body?.getReader()
-  if (!reader) {
-    throw new Error('Response body is not readable')
-  }
-
-  const tmpPath = destPath + '.tmp'
-  const writeStream = fs.createWriteStream(tmpPath)
-  let downloadedBytes = 0
 
   try {
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-
-      writeStream.write(Buffer.from(value))
-      downloadedBytes += value.byteLength
-
-      if (onProgress && totalBytes > 0) {
-        onProgress({
-          percent: (downloadedBytes / totalBytes) * 100,
-          downloadedBytes,
-          totalBytes
-        })
-      }
-    }
-  } catch (err) {
-    writeStream.end()
-    // Clean up partial download
-    try { fs.unlinkSync(tmpPath) } catch {}
-    activeDownloads.delete(downloadKey(repo, filename))
-    throw err
+    await downloadAndVerifySha256(
+      downloadUrl,
+      destPath,
+      expectedSha256,
+      onProgress
+        ? (percent, downloadedBytes, totalBytes) => {
+            onProgress({ percent, downloadedBytes, totalBytes })
+          }
+        : undefined,
+      { headers, signal: abortController.signal }
+    )
   } finally {
-    writeStream.end()
-    await new Promise((resolve) => writeStream.on('finish', resolve))
+    activeDownloads.delete(key)
   }
 
-  // Rename tmp to final
-  fs.renameSync(tmpPath, destPath)
-  activeDownloads.delete(downloadKey(repo, filename))
+  const entry = recordManifest(repo, filename, destPath, expectedSha256)
+  log.info(`[huggingface] Downloaded and verified: ${repo}/${filename} (${entry.size} bytes)`)
+  return destPath
+}
 
-  // Update manifest
+const recordManifest = (
+  repo: string,
+  filename: string,
+  destPath: string,
+  sha256: string
+): HfModel => {
   const manifest = readManifest()
   const existing = manifest.findIndex((m) => m.repo === repo && m.filename === filename)
   const entry: HfModel = {
@@ -247,7 +229,8 @@ export const downloadModel = async (
     filename,
     filepath: destPath,
     size: fs.statSync(destPath).size,
-    downloadedAt: new Date().toISOString()
+    downloadedAt: new Date().toISOString(),
+    sha256
   }
   if (existing >= 0) {
     manifest[existing] = entry
@@ -255,17 +238,14 @@ export const downloadModel = async (
     manifest.push(entry)
   }
   writeManifest(manifest)
-
-  log.info(`[huggingface] Downloaded: ${destPath} (${entry.size} bytes)`)
-  return destPath
+  return entry
 }
 
 /**
  * Delete a downloaded model.
  */
 export const deleteModel = (repo: string, filename: string): boolean => {
-  const slug = repoSlug(repo)
-  const filepath = path.join(getHfCacheDir(), slug, filename)
+  const filepath = confinedModelPath(getHfCacheDir(), repo, filename)
 
   try {
     if (fs.existsSync(filepath)) {
@@ -282,7 +262,7 @@ export const deleteModel = (repo: string, filename: string): boolean => {
   writeManifest(updated)
 
   // Clean up empty repo dir
-  const repoDir = path.join(getHfCacheDir(), slug)
+  const repoDir = path.dirname(filepath)
   try {
     const remaining = fs.readdirSync(repoDir)
     if (remaining.length === 0) {
@@ -317,6 +297,7 @@ export interface HfRepoResult {
 export interface HfFileInfo {
   filename: string
   size: number          // bytes
+  sha256?: string
   lfs?: { size: number }
 }
 
@@ -365,7 +346,7 @@ export const getRepoFiles = async (
   const headers: Record<string, string> = { Accept: 'application/json' }
   if (token) headers['Authorization'] = `Bearer ${token}`
 
-  const response = await fetch(`https://huggingface.co/api/models/${repo}`, { headers })
+  const response = await fetch(huggingfaceRepoApiUrl(repo), { headers })
   if (!response.ok) {
     throw new Error(`Failed to fetch repo info: ${response.status} ${response.statusText}`)
   }
@@ -373,13 +354,40 @@ export const getRepoFiles = async (
   const data = await response.json()
   const siblings = data.siblings ?? []
 
-  // Filter to only GGUF files
   return siblings
-    .filter((f: any) => f.rfilename?.endsWith('.gguf'))
-    .map((f: any) => ({
-      filename: f.rfilename,
-      size: f.lfs?.size ?? f.size ?? 0
-    }))
+    .filter((f: { rfilename?: string }) => f.rfilename?.endsWith('.gguf'))
+    .map((f: { rfilename: string; size?: number; lfs?: { size?: number; sha256?: string } }) => {
+      let sha256: string | undefined
+      try {
+        sha256 = parseHfLfsSha256(f.lfs)
+      } catch {
+        sha256 = undefined
+      }
+      return {
+        filename: f.rfilename,
+        size: f.lfs?.size ?? f.size ?? 0,
+        sha256,
+        lfs: f.lfs?.size != null ? { size: f.lfs.size } : undefined
+      }
+    })
     .sort((a: HfFileInfo, b: HfFileInfo) => a.size - b.size)
+}
+
+/**
+ * Resolve the GGUF content SHA-256 from the Hub. Fail closed if the file is
+ * missing or has no LFS sha256 — git blob ids are not a content hash.
+ */
+export const fetchHfGgufSha256 = async (
+  repo: string,
+  filename: string,
+  token?: string
+): Promise<string> => {
+  const safeFile = assertSafeFilename(filename)
+  const files = await getRepoFiles(repo, token)
+  const match = files.find((f) => f.filename === safeFile)
+  if (!match?.sha256) {
+    throw new Error(`Hugging Face file is missing LFS SHA-256: ${repo}/${safeFile}`)
+  }
+  return match.sha256
 }
 

--- a/src/main/utils/index.ts
+++ b/src/main/utils/index.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 
 import * as fs from 'fs'
 import * as os from 'os'
@@ -8,8 +7,17 @@ import crypto from 'crypto'
 
 import * as tar from 'tar'
 
-import { app, shell, Notification, net as electronNet } from 'electron'
-import { execFileSync, exec, spawn, execSync, execFile } from 'child_process'
+import { app, net as electronNet } from 'electron'
+import { openExternalUrl } from '../safe-open'
+import {
+  PYTHON_SHA256,
+  assertSha256,
+  downloadAndVerifySha256,
+  fileMatchesSha256
+} from './artifact-integrity'
+import { sanitizeChildEnv } from './child-env'
+import { errorMessage } from './error-message'
+import { execFileSync, execSync, execFile } from 'child_process'
 
 import log from 'electron-log'
 log.transports.file.resolvePathFn = () => getLogFilePath('main')
@@ -98,14 +106,8 @@ export const getOpenWebUIDataPath = (): string => {
 }
 
 export const openUrl = (url: string) => {
-  if (!url) {
-    throw new Error('No URL provided to open in browser.')
-  }
   log.info('Opening URL in browser:', url)
-  if (url.startsWith('http://0.0.0.0')) {
-    url = url.replace('http://0.0.0.0', 'http://localhost')
-  }
-  shell.openExternal(url)
+  return openExternalUrl(url)
 }
 
 export const getSystemInfo = () => {
@@ -168,47 +170,36 @@ const getArchString = () => {
 }
 
 const generateDownloadUrl = () => {
-  const baseUrl = 'https://github.com/astral-sh/python-build-standalone/releases/download'
   const releaseDate = '20260310'
   const pythonVersion = '3.12.13'
-  const archString = getArchString()
-  const platformString = getPlatformString()
-  const filename = `cpython-${pythonVersion}+${releaseDate}-${archString}-${platformString}-install_only.tar.gz`
-  return `${baseUrl}/${releaseDate}/${filename}`
+  const filename = `cpython-${pythonVersion}+${releaseDate}-${getArchString()}-${getPlatformString()}-install_only.tar.gz`
+  const sha256 = PYTHON_SHA256[filename]
+  if (!sha256) {
+    throw new Error(
+      `No pinned SHA-256 for Python standalone archive ${filename} (${os.platform()} ${os.arch()})`
+    )
+  }
+  return {
+    url: `https://github.com/astral-sh/python-build-standalone/releases/download/${releaseDate}/${filename}`,
+    filename,
+    sha256
+  }
 }
 
-export const downloadFileWithProgress = async (url, downloadPath, onProgress) => {
+export const downloadFileWithProgress = async (
+  url: string,
+  downloadPath: string,
+  onProgress: ((percent: number, downloaded: number, total: number) => void) | undefined,
+  expectedSha256: string
+) => {
+  if (!expectedSha256) {
+    throw new Error('Refusing to download without a SHA-256 digest')
+  }
   try {
-    const response = await fetch(url)
-    if (!response || !response.ok) {
-      throw new Error(`HTTP error! status: ${response?.status}`)
-    }
-    const totalSize = parseInt(response.headers.get('content-length'), 10)
-    let downloadedSize = 0
-    const reader = response.body.getReader()
-    const chunks = []
-
-    while (true) {
-      const { done, value } = await reader.read()
-      if (done) break
-      chunks.push(value)
-      downloadedSize += value.length
-      if (onProgress && totalSize) {
-        onProgress((downloadedSize / totalSize) * 100, downloadedSize, totalSize)
-      }
-    }
-
-    const buffer = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)))
-    fs.writeFileSync(downloadPath, buffer)
-    log.info('File downloaded successfully:', downloadPath)
-    return downloadPath
+    const result = await downloadAndVerifySha256(url, downloadPath, expectedSha256, onProgress)
+    log.info('File downloaded and verified:', downloadPath)
+    return result
   } catch (error) {
-    // Clean up partial downloads
-    try {
-      if (fs.existsSync(downloadPath)) {
-        fs.unlinkSync(downloadPath)
-      }
-    } catch {}
     log.error('Download failed:', error)
     throw error
   }
@@ -230,8 +221,10 @@ export const getPythonInstallationDir = (): string => {
   return path.normalize(pythonDir)
 }
 
-const downloadPython = async (onProgress = null) => {
-  const url = generateDownloadUrl()
+const downloadPython = async (
+  onProgress?: (percent: number, downloaded: number, total: number) => void
+) => {
+  const { url, sha256 } = generateDownloadUrl()
   const downloadPath = getPythonDownloadPath()
 
   log.info(`Detected system: ${os.platform()} ${os.arch()}`)
@@ -239,16 +232,22 @@ const downloadPython = async (onProgress = null) => {
   log.info(`URL: ${url}`)
 
   if (fs.existsSync(downloadPath)) {
-    log.info(`File already exists: ${downloadPath}`)
-    return downloadPath
+    if (fileMatchesSha256(downloadPath, sha256)) {
+      log.info(`Using verified cached Python archive: ${downloadPath}`)
+      return downloadPath
+    }
+    log.warn(`Cached Python archive failed checksum; re-downloading: ${downloadPath}`)
+    try {
+      fs.unlinkSync(downloadPath)
+    } catch {}
   }
 
   try {
-    const result = await downloadFileWithProgress(url, downloadPath, onProgress)
-    log.info(`Python downloaded successfully to: ${result}`)
+    const result = await downloadFileWithProgress(url, downloadPath, onProgress, sha256)
+    log.info(`Python downloaded and verified: ${result}`)
     return result
   } catch (error) {
-    log.error(`Download failed: ${error?.message}`)
+    log.error(`Download failed: ${errorMessage(error)}`)
     throw error
   }
 }
@@ -263,8 +262,11 @@ const checkInternet = async () => {
 }
 
 export const installPython = async (installationDir?: string, onStatus?: (status: string) => void): Promise<boolean> => {
+  const { sha256 } = generateDownloadUrl()
   const pythonDownloadPath = getPythonDownloadPath()
-  if (!fs.existsSync(pythonDownloadPath)) {
+  const cacheOk =
+    fs.existsSync(pythonDownloadPath) && fileMatchesSha256(pythonDownloadPath, sha256)
+  if (!cacheOk) {
     if (!(await checkInternet())) {
       throw new Error(
         'An active internet connection is required. Please connect to the internet and try again.'
@@ -285,6 +287,7 @@ export const installPython = async (installationDir?: string, onStatus?: (status
     log.error('Python download not found')
     return false
   }
+  assertSha256(pythonDownloadPath, sha256)
 
   installationDir = installationDir || getPythonInstallationDir()
   log.info(installationDir, pythonDownloadPath)
@@ -331,7 +334,7 @@ export const installPython = async (installationDir?: string, onStatus?: (status
   } catch (error) {
     log.error('Failed to install uv:', error)
     throw new Error(
-      `Failed to install the uv package manager: ${error?.message || 'unknown error'}`
+      `Failed to install the uv package manager: ${errorMessage(error)}`
     )
   }
 }
@@ -362,21 +365,21 @@ export const getPythonPath = (installationDir?: string) => {
  * Windows finds the correct DLLs first.  On non-Windows platforms this is a
  * harmless no-op.
  *
- * Any additional env overrides (e.g. `configEnvVars`) can be spread after
- * calling this helper.
+ * `configEnvVars` are merged here; dangerous keys (LD_PRELOAD, NODE_OPTIONS,
+ * PYTHONHOME, …) are stripped by `sanitizeChildEnv`.
  */
-const pythonEnv = (extra: Record<string, string> = {}): Record<string, string> => {
-  const base: Record<string, string> = { ...process.env }
+export const pythonEnv = (extra: Record<string, string> = {}): Record<string, string> => {
+  const env = sanitizeChildEnv(extra)
 
   if (process.platform === 'win32') {
     // python.exe lives at the root of the installation directory on Windows
     const pythonDir = getPythonInstallationDir()
-    const currentPath = process.env['PATH'] || process.env['Path'] || ''
-    base['PATH'] = `${pythonDir};${currentPath}`
-    base['PYTHONIOENCODING'] = 'utf-8'
+    const currentPath = env['PATH'] || env['Path'] || ''
+    env['PATH'] = `${pythonDir};${currentPath}`
+    env['PYTHONIOENCODING'] = 'utf-8'
   }
 
-  return { ...base, ...extra }
+  return env
 }
 
 export const isPythonInstalled = (installationDir?: string) => {
@@ -551,14 +554,14 @@ import * as pty from 'node-pty'
 
 const serverPIDs: Set<number> = new Set()
 const serverLogs: Map<number, string[]> = new Map()
-let serverPtyProcesses: Map<number, pty.IPty> = new Map()
+const serverPtyProcesses: Map<number, pty.IPty> = new Map()
 
 export const getServerPIDs = (): number[] => Array.from(serverPIDs)
 export const getServerPty = (pid: number): pty.IPty | undefined => serverPtyProcesses.get(pid)
 
 export const startServer = async (
   expose = false,
-  port = null
+  port: number | null = null
 ): Promise<{ url: string; pid: number }> => {
   await stopAllServers()
   const config = await getConfig()
@@ -582,7 +585,7 @@ export const startServer = async (
   }
 
   // Find available port
-  let desiredPort = port || 8080
+  const desiredPort = port || 8080
   let availablePort = desiredPort
   while (await portInUse(availablePort, host)) {
     availablePort++
@@ -608,7 +611,7 @@ export const startServer = async (
     })
   } catch (error) {
     throw new Error(
-      `Failed to spawn PTY with ${pythonPath}: ${error?.message ?? error}`
+      `Failed to spawn PTY with ${pythonPath}: ${errorMessage(error)}`
     )
   }
 
@@ -821,12 +824,14 @@ export interface AppConfig {
     port: number
     serveOnLocalNetwork: boolean
     autoUpdate: boolean
+    version?: string
   }
   openTerminal: {
     enabled: boolean
     port: number
     cwd: string
     apiKey: string
+    version?: string
   }
   llamaCpp: {
     enabled: boolean
@@ -863,11 +868,13 @@ const DEFAULT_CONFIG: AppConfig = {
   },
   openTerminal: {
     enabled: false,
+    port: 39284,
     cwd: '',
     apiKey: ''
   },
   llamaCpp: {
     enabled: false,
+    port: 18881,
     version: 'latest',
     variant: 'cpu',
     extraArgs: []

--- a/src/main/utils/llama-release.ts
+++ b/src/main/utils/llama-release.ts
@@ -1,0 +1,35 @@
+export interface GithubReleaseAsset {
+  name: string
+  browser_download_url: string
+  digest?: string
+}
+
+export interface GithubRelease {
+  tag_name: string
+  draft?: boolean
+  assets?: GithubReleaseAsset[]
+}
+
+export function releaseHasLlamaBinaries(release: GithubRelease): boolean {
+  if (release.draft) return false
+  return (release.assets ?? []).some(
+    (asset) =>
+      typeof asset.name === 'string' &&
+      asset.name.includes('-bin-') &&
+      typeof asset.digest === 'string' &&
+      asset.digest.startsWith('sha256:')
+  )
+}
+
+/**
+ * GitHub `latest` for ggml-org/llama.cpp is sometimes a stable tag with no
+ * binaries (e.g. v0.4.0). Binary builds live on `b*` releases, often marked
+ * prerelease. Pick the newest listed release that actually has hashed bins.
+ */
+export function pickLatestLlamaCppRelease(releases: GithubRelease[]): GithubRelease {
+  const picked = releases.find(releaseHasLlamaBinaries)
+  if (!picked) {
+    throw new Error('No llama.cpp GitHub release with binary assets found')
+  }
+  return picked
+}

--- a/src/main/utils/llamacpp.ts
+++ b/src/main/utils/llamacpp.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 
 import * as fs from 'fs'
 import * as path from 'path'
@@ -15,6 +14,14 @@ import {
   portInUse,
   downloadFileWithProgress
 } from './index'
+import { parseGithubDigest, fileMatchesSha256, assertSha256 } from './artifact-integrity'
+import { sanitizeChildEnv, sanitizeLlamaExtraArgs } from './child-env'
+import { errorMessage } from './error-message'
+import {
+  pickLatestLlamaCppRelease,
+  type GithubRelease,
+  type GithubReleaseAsset
+} from './llama-release'
 
 import { getModelsDir } from './huggingface'
 import { ServiceLock, isProcessAlive } from './service-lock'
@@ -71,9 +78,32 @@ export const getLlamaCppLog = (): string[] => logBuffer
 
 // ─── Asset Resolution ───────────────────────────────────
 
-interface ReleaseAsset {
-  name: string
-  browser_download_url: string
+type ReleaseAsset = GithubReleaseAsset
+
+const LLAMA_RELEASES_API = 'https://api.github.com/repos/ggml-org/llama.cpp/releases'
+
+async function githubJson(url: string, timeoutMs = 10000): Promise<unknown> {
+  const response = await fetch(url, {
+    headers: { Accept: 'application/vnd.github.v3+json' },
+    signal: AbortSignal.timeout(timeoutMs)
+  })
+  if (!response.ok) {
+    throw new Error(`GitHub API returned ${response.status}: ${response.statusText}`)
+  }
+  return response.json()
+}
+
+async function fetchLlamaCppRelease(version: string): Promise<GithubRelease> {
+  if (version !== 'latest') {
+    return (await githubJson(
+      `${LLAMA_RELEASES_API}/tags/${encodeURIComponent(version)}`
+    )) as GithubRelease
+  }
+  const releases = (await githubJson(`${LLAMA_RELEASES_API}?per_page=30`)) as GithubRelease[]
+  if (!Array.isArray(releases)) {
+    throw new Error('GitHub releases response was not a list')
+  }
+  return pickLatestLlamaCppRelease(releases)
 }
 
 /**
@@ -255,21 +285,9 @@ export const setupLlamaCpp = async (
   }
 
   onStatus?.('Fetching release info…')
-  const apiUrl =
-    version === 'latest'
-      ? 'https://api.github.com/repos/ggml-org/llama.cpp/releases/latest'
-      : `https://api.github.com/repos/ggml-org/llama.cpp/releases/tags/${version}`
-
-  let releaseData: any
+  let releaseData: GithubRelease
   try {
-    const response = await fetch(apiUrl, {
-      headers: { Accept: 'application/vnd.github.v3+json' },
-      signal: AbortSignal.timeout(10000)
-    })
-    if (!response.ok) {
-      throw new Error(`GitHub API returned ${response.status}: ${response.statusText}`)
-    }
-    releaseData = await response.json()
+    releaseData = await fetchLlamaCppRelease(version)
   } catch (error) {
     // Network unavailable — fall back to cached binary if we found one
     if (binaryPath) {
@@ -280,7 +298,7 @@ export const setupLlamaCpp = async (
     throw new Error(
       `Failed to fetch release info (no internet?) and no cached llama.cpp binary found. ` +
       `Please connect to the internet for the initial llama.cpp installation. ` +
-      `Original error: ${error?.message ?? error}`
+      `Original error: ${errorMessage(error)}`
     )
   }
 
@@ -308,31 +326,51 @@ export const setupLlamaCpp = async (
     )
   }
 
-  log.info(`Downloading asset: ${asset.name}`)
+  const sha256 = parseGithubDigest(asset.digest)
+  log.info(`Downloading asset: ${asset.name} (sha256 ${sha256})`)
   onStatus?.(`Downloading ${asset.name}…`)
 
   const downloadPath = path.join(versionDir, asset.name)
-  if (!fs.existsSync(downloadPath)) {
-    await downloadFileWithProgress(asset.browser_download_url, downloadPath, (progress) => {
-      onStatus?.(`Downloading… ${progress.toFixed(0)}%`)
-    })
+  if (!fs.existsSync(downloadPath) || !fileMatchesSha256(downloadPath, sha256)) {
+    if (fs.existsSync(downloadPath)) {
+      log.warn(`Cached llama.cpp archive failed checksum; re-downloading: ${downloadPath}`)
+      try {
+        fs.unlinkSync(downloadPath)
+      } catch {}
+    }
+    await downloadFileWithProgress(
+      asset.browser_download_url,
+      downloadPath,
+      (progress) => {
+        onStatus?.(`Downloading… ${progress.toFixed(0)}%`)
+      },
+      sha256
+    )
   }
 
+  assertSha256(downloadPath, sha256)
   onStatus?.('Extracting…')
   log.info(`Extracting ${downloadPath} to ${versionDir}`)
 
   if (isZip) {
     try {
       if (process.platform === 'win32') {
-        execFileSync('powershell', [
-          '-Command',
-          `Expand-Archive -Path "${downloadPath}" -DestinationPath "${versionDir}" -Force`
-        ])
+        execFileSync(
+          'powershell',
+          ['-NoProfile', '-Command', 'Expand-Archive -LiteralPath $env:OWUI_ZIP -DestinationPath $env:OWUI_DEST -Force'],
+          {
+            env: {
+              ...process.env,
+              OWUI_ZIP: downloadPath,
+              OWUI_DEST: versionDir
+            }
+          }
+        )
       } else {
         execFileSync('unzip', ['-o', downloadPath, '-d', versionDir])
       }
     } catch (error) {
-      throw new Error(`Failed to extract zip: ${error?.message ?? error}`)
+      throw new Error(`Failed to extract zip: ${errorMessage(error)}`)
     }
   } else {
     await tar.x({ cwd: versionDir, file: downloadPath })
@@ -366,16 +404,7 @@ export const checkLlamaCppUpdate = async (): Promise<{ currentVersion: string | 
   const currentInfo = getLlamaCppInfo()
 
   try {
-    const response = await fetch('https://api.github.com/repos/ggml-org/llama.cpp/releases/latest', {
-      headers: { Accept: 'application/vnd.github.v3+json' },
-      signal: AbortSignal.timeout(5000)
-    })
-    
-    if (!response.ok) {
-      throw new Error(`GitHub API returned ${response.status}: ${response.statusText}`)
-    }
-    
-    const releaseData = await response.json()
+    const releaseData = await fetchLlamaCppRelease('latest')
     const latestVersion = releaseData.tag_name
     const currentVersion = currentInfo.version
     
@@ -400,28 +429,19 @@ export const checkLlamaCppUpdate = async (): Promise<{ currentVersion: string | 
 
 export const updateLlamaCpp = async (
   onStatus?: (status: string) => void
-): Promise<{ url?: string; status?: string; pid?: number; binaryPath?: string; version?: string | null }> => {
+): Promise<ReturnType<typeof getLlamaCppInfo>> => {
   // 1. Verify network is available BEFORE destructive operations —
   //    don't delete the old binary if we can't download a replacement.
   onStatus?.('Checking for updates…')
   let releaseTag: string
   try {
-    const response = await fetch(
-      'https://api.github.com/repos/ggml-org/llama.cpp/releases/latest',
-      {
-        headers: { Accept: 'application/vnd.github.v3+json' },
-        signal: AbortSignal.timeout(10000)
-      }
-    )
-    if (!response.ok) {
-      throw new Error(`GitHub API returned ${response.status}: ${response.statusText}`)
-    }
-    const data = await response.json()
+    const data = await fetchLlamaCppRelease('latest')
     releaseTag = data.tag_name
+    log.info(`Updating llama.cpp from GitHub latest with binaries: ${releaseTag}`)
   } catch (error) {
     throw new Error(
       `Cannot update llama.cpp: unable to reach GitHub. ` +
-      `Please check your internet connection. (${error?.message ?? error})`
+      `Please check your internet connection. (${errorMessage(error)})`
     )
   }
 
@@ -459,10 +479,14 @@ export const startLlamaCpp = async (
   onStatus?: (status: string) => void
 ): Promise<{ url: string; pid: number }> => {
   if (!lock.acquire()) {
+    if (url == null || pid == null) {
+      throw new Error('llama-server start is already in progress')
+    }
     return { url, pid }
   }
 
-  await stopLlamaCpp()
+  try {
+    await stopLlamaCpp({ retainLock: true })
 
   status = 'setting-up'
   onStatus?.('Setting up llama.cpp…')
@@ -476,7 +500,7 @@ export const startLlamaCpp = async (
   const llamaConfig = config.llamaCpp ?? {}
   const host = '127.0.0.1'
 
-  let desiredPort = llamaConfig.port || 18881
+  const desiredPort = llamaConfig.port || 18881
   let availablePort = desiredPort
   while (await portInUse(availablePort, host)) {
     availablePort++
@@ -485,9 +509,18 @@ export const startLlamaCpp = async (
     }
   }
 
-  const extraArgs = llamaConfig.extraArgs ?? []
+  const extraArgs = sanitizeLlamaExtraArgs(llamaConfig.extraArgs)
   const modelsDir = getModelsDir()
-  const commandArgs = ['--host', host, '--port', availablePort.toString(), '--models-dir', modelsDir, ...extraArgs]
+  // Bind address, port, and models dir always win over extraArgs.
+  const commandArgs = [
+    ...extraArgs,
+    '--models-dir',
+    modelsDir,
+    '--host',
+    host,
+    '--port',
+    availablePort.toString()
+  ]
 
   log.info('Starting llama-server:', binary, commandArgs.join(' '))
 
@@ -497,14 +530,11 @@ export const startLlamaCpp = async (
       name: 'xterm-256color',
       cols: 200,
       rows: 50,
-      env: {
-        ...process.env,
-        ...(config.envVars ?? {})
-      }
+      env: sanitizeChildEnv(config.envVars ?? {})
     })
   } catch (error) {
     status = 'failed'
-    throw new Error(`Failed to spawn llama-server: ${error?.message ?? error}`)
+    throw new Error(`Failed to spawn llama-server: ${errorMessage(error)}`)
   }
 
   const spawnedPid = spawned.pid
@@ -521,10 +551,13 @@ export const startLlamaCpp = async (
     log.info(`[llamacpp:${spawnedPid}] Exited code=${exitCode} signal=${signal}`)
     const exitMsg = `\r\n[Process exited with code ${exitCode}${signal ? ` signal ${signal}` : ''}]\r\n`
     logBuffer.push(exitMsg)
-    ptyProcess = null
-    pid = null
-    url = null
-    status = 'stopped'
+    if (ptyProcess === spawned) {
+      ptyProcess = null
+      pid = null
+      url = null
+      status = 'stopped'
+      lock.release()
+    }
   })
 
   const serverUrl = `http://${host}:${availablePort}`
@@ -555,32 +588,39 @@ export const startLlamaCpp = async (
   status = 'started'
   log.info(`llama-server started — PID: ${spawnedPid}, URL: ${serverUrl}`)
 
-  return { url: serverUrl, pid: spawnedPid }
+    return { url: serverUrl, pid: spawnedPid }
+  } catch (error) {
+    lock.release()
+    throw error
+  }
 }
 
-export const stopLlamaCpp = async (): Promise<void> => {
-  if (ptyProcess) {
-    try {
-      ptyProcess.kill()
-    } catch (e) {
-      log.warn('Failed to kill llama-server PTY:', e)
-    }
-    await new Promise((r) => setTimeout(r, 2000))
-    if (pid) {
-      try {
-        process.kill(pid, 0)
-        process.kill(pid, 'SIGKILL')
-      } catch {
-        // already dead
-      }
-    }
-  }
+export const stopLlamaCpp = async (opts?: { retainLock?: boolean }): Promise<void> => {
+  const proc = ptyProcess
+  const procPid = pid
+  // Detach before kill so onExit does not release a lock start() is retaining.
   ptyProcess = null
   pid = null
   url = null
   status = null
   logBuffer = []
-  lock.release()
+  if (proc) {
+    try {
+      proc.kill()
+    } catch (e) {
+      log.warn('Failed to kill llama-server PTY:', e)
+    }
+    await new Promise((r) => setTimeout(r, 2000))
+    if (procPid) {
+      try {
+        process.kill(procPid, 0)
+        process.kill(procPid, 'SIGKILL')
+      } catch {
+        // already dead
+      }
+    }
+  }
+  if (!opts?.retainLock) lock.release()
 }
 
 /**

--- a/src/main/utils/open-terminal.ts
+++ b/src/main/utils/open-terminal.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 
 import crypto from 'crypto'
 import log from 'electron-log'
@@ -11,9 +10,11 @@ import {
   isPackageInstalled,
   isPythonInstalled,
   installPython,
-  portInUse
+  portInUse,
+  pythonEnv
 } from './index'
 import { ServiceLock, isProcessAlive } from './service-lock'
+import { errorMessage } from './error-message'
 
 // ─── State ──────────────────────────────────────────────
 
@@ -43,10 +44,14 @@ export const startOpenTerminal = async (
   onStatus?: (status: string) => void
 ): Promise<{ url: string; apiKey: string; pid: number }> => {
   if (!lock.acquire()) {
+    if (url == null || apiKey == null || pid == null) {
+      throw new Error('Open Terminal start is already in progress')
+    }
     return { url, apiKey, pid }
   }
 
-  await stopOpenTerminal()
+  try {
+    await stopOpenTerminal({ retainLock: true })
 
   if (!isPythonInstalled()) {
     log.info('Python not installed — installing automatically for Open Terminal…')
@@ -56,7 +61,7 @@ export const startOpenTerminal = async (
       if (!ok) throw new Error('Python installation returned false')
     } catch (err) {
       throw new Error(
-        `Python is required for Open Terminal but installation failed: ${err?.message ?? err}`
+        `Python is required for Open Terminal but installation failed: ${errorMessage(err)}`
       )
     }
     if (!isPythonInstalled()) {
@@ -74,7 +79,7 @@ export const startOpenTerminal = async (
     } catch (err) {
       throw new Error(
         `Open Terminal is not installed and auto-install failed. ` +
-        `Please connect to the internet and try again. (${err?.message ?? err})`
+        `Please connect to the internet and try again. (${errorMessage(err)})`
       )
     }
   }
@@ -94,7 +99,7 @@ export const startOpenTerminal = async (
   }
 
   // Find available port
-  let desiredPort = port || 39284
+  const desiredPort = port || 39284
   let availablePort = desiredPort
   while (await portInUse(availablePort, host)) {
     availablePort++
@@ -113,7 +118,9 @@ export const startOpenTerminal = async (
     '--cwd', cwd
   ]
 
-  log.info('Starting Open Terminal...', pythonPath, commandArgs.join(' '))
+  log.info(
+    `Starting Open Terminal... ${pythonPath} -m uv run open-terminal run --host ${host} --port ${availablePort}`
+  )
 
   let spawned: pty.IPty
   try {
@@ -121,16 +128,14 @@ export const startOpenTerminal = async (
       name: 'xterm-256color',
       cols: 200,
       rows: 50,
-      env: {
-        ...process.env,
+      env: pythonEnv({
         ...(configEnvVars ?? {}),
-        PYTHONUNBUFFERED: '1',
-        ...(process.platform === 'win32' ? { PYTHONIOENCODING: 'utf-8' } : {})
-      }
+        PYTHONUNBUFFERED: '1'
+      })
     })
   } catch (error) {
     throw new Error(
-      `Failed to spawn Open Terminal: ${error?.message ?? error}`
+      `Failed to spawn Open Terminal: ${errorMessage(error)}`
     )
   }
 
@@ -148,11 +153,14 @@ export const startOpenTerminal = async (
 
   spawned.onExit(({ exitCode, signal }) => {
     log.info(`[OpenTerminal:${spawnedPid}] Exited code=${exitCode} signal=${signal}`)
-    ptyProcess = null
-    pid = null
-    url = null
-    apiKey = null
-    status = 'stopped'
+    if (ptyProcess === spawned) {
+      ptyProcess = null
+      pid = null
+      url = null
+      apiKey = null
+      status = 'stopped'
+      lock.release()
+    }
   })
 
   const serverUrl = `http://${host}:${availablePort}`
@@ -160,35 +168,39 @@ export const startOpenTerminal = async (
   status = 'started'
   log.info(`Open Terminal started — PID: ${spawnedPid}, URL: ${serverUrl}`)
 
-  return { url: serverUrl, apiKey: generatedKey, pid: spawnedPid }
+    return { url: serverUrl, apiKey: generatedKey, pid: spawnedPid }
+  } catch (error) {
+    lock.release()
+    throw error
+  }
 }
 
-export const stopOpenTerminal = async (): Promise<void> => {
-  if (ptyProcess) {
-    try {
-      ptyProcess.kill()
-    } catch (e) {
-      log.warn('Failed to kill Open Terminal PTY:', e)
-    }
-    // Give it a moment to exit
-    await new Promise((r) => setTimeout(r, 1000))
-    // Force kill if still running
-    if (pid) {
-      try {
-        process.kill(pid, 0) // check alive
-        process.kill(pid, 'SIGKILL')
-      } catch {
-        // already dead
-      }
-    }
-  }
+export const stopOpenTerminal = async (opts?: { retainLock?: boolean }): Promise<void> => {
+  const proc = ptyProcess
+  const procPid = pid
   ptyProcess = null
   pid = null
   url = null
   apiKey = null
   status = null
   logBuffer = []
-  lock.release()
+  if (proc) {
+    try {
+      proc.kill()
+    } catch (e) {
+      log.warn('Failed to kill Open Terminal PTY:', e)
+    }
+    await new Promise((r) => setTimeout(r, 1000))
+    if (procPid) {
+      try {
+        process.kill(procPid, 0)
+        process.kill(procPid, 'SIGKILL')
+      } catch {
+        // already dead
+      }
+    }
+  }
+  if (!opts?.retainLock) lock.release()
 }
 
 /**

--- a/src/main/utils/safe-pty.ts
+++ b/src/main/utils/safe-pty.ts
@@ -1,0 +1,27 @@
+/**
+ * node-pty throws from the main process if resize/write runs after the
+ * child has exited (Windows: "already exited"; Linux: ioctl EBADF).
+ * That exception is uncaught and kills the whole Electron app (#255).
+ */
+
+export function safePtyResize(
+  pty: { resize: (cols: number, rows: number) => void },
+  cols: number,
+  rows: number
+): boolean {
+  try {
+    pty.resize(cols, rows)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function safePtyWrite(pty: { write: (data: string) => void }, data: string): boolean {
+  try {
+    pty.write(data)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/main/utils/service-lock.ts
+++ b/src/main/utils/service-lock.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 
 /**
  * ServiceLock — reusable singleton lock for managed child processes.
@@ -10,8 +9,14 @@
  * Usage:
  *   const lock = new ServiceLock('my-service')
  *   if (!lock.acquire()) return existingResult
- *   try { ... } catch { lock.release() }
- *   // release in stop(), not in start()
+ *   try {
+ *     await stop({ retainLock: true })
+ *     // spawn...
+ *   } catch {
+ *     lock.release()
+ *     throw
+ *   }
+ *   // release in stop() / onExit, not after a successful start
  */
 
 import log from 'electron-log'

--- a/src/main/webview-navigation.ts
+++ b/src/main/webview-navigation.ts
@@ -1,0 +1,88 @@
+const AUTH_HOSTS = new Set([
+  'accounts.google.com',
+  'login.microsoftonline.com',
+  'login.live.com',
+  'appleid.apple.com'
+])
+
+const AUTH_HOST_SUFFIXES = ['.cloudflareaccess.com']
+
+const AUTH_PATH =
+  /\/cdn-cgi\/access(?:\/|$)|\/application\/o\/|\/if\/flow\/|\/realms\/|\/oauth2?\/|\/oidc\/|\/saml2?\/|\/login\/oauth|\/authorize\/?$/i
+
+export function loggableUrl(url: string): string {
+  try {
+    const parsed = new URL(url)
+    return `${parsed.origin}${parsed.pathname}`
+  } catch {
+    return '(invalid url)'
+  }
+}
+
+export function isAccessCallbackUrl(url: string): boolean {
+  try {
+    const path = new URL(url).pathname
+    return (
+      path.includes('/cdn-cgi/access/callback') ||
+      path.includes('/cdn-cgi/access/authorized')
+    )
+  } catch {
+    return false
+  }
+}
+
+export function originOf(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+    if (parsed.hostname === '0.0.0.0') {
+      parsed.hostname = '127.0.0.1'
+    }
+    return parsed.origin
+  } catch {
+    return null
+  }
+}
+
+export function isLikelyAuthUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    const host = parsed.hostname.toLowerCase()
+    if (AUTH_HOSTS.has(host)) return true
+    if (AUTH_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))) return true
+    if (host === 'github.com' && parsed.pathname.toLowerCase().startsWith('/login')) return true
+    if (AUTH_PATH.test(parsed.pathname)) return true
+    const query = parsed.searchParams
+    if (query.has('client_id') && (query.has('redirect_uri') || query.has('response_type'))) {
+      return true
+    }
+    if (query.has('SAMLRequest') || query.has('SAMLResponse')) return true
+    return false
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Chat links from the Open WebUI origin should open in the OS browser (#165).
+ * Cloudflare Access / OIDC / SAML must stay in the webview partition so the
+ * session cookie is set on the guest, not in Chrome.
+ */
+export function shouldOpenInSystemBrowser(opts: {
+  currentUrl: string
+  targetUrl: string
+  homeOrigin: string | null
+}): boolean {
+  const targetOrigin = originOf(opts.targetUrl)
+  if (!targetOrigin) return false
+
+  const currentOrigin = originOf(opts.currentUrl)
+  if (!currentOrigin) return false
+
+  if (targetOrigin === currentOrigin) return false
+  if (opts.homeOrigin && targetOrigin === opts.homeOrigin) return false
+  if (isLikelyAuthUrl(opts.targetUrl) || isLikelyAuthUrl(opts.currentUrl)) return false
+  if (opts.homeOrigin && currentOrigin !== opts.homeOrigin) return false
+
+  return true
+}

--- a/src/preload/content-preload.ts
+++ b/src/preload/content-preload.ts
@@ -1,13 +1,12 @@
 import { ipcRenderer, contextBridge } from 'electron'
 
-// ─── Desktop ↔ Open WebUI Generic Protocol ──────────────
-// This preload is a dumb relay. It passes typed {type, data}
-// messages between the embedder (desktop renderer) and the
-// Open WebUI page. Business logic lives elsewhere.
-// To add new features, just add new event types — this file
-// never needs to change.
+// Guest Open WebUI is untrusted (remote URL or XSS in the local UI).
+// Only these send() types are forwarded to the embedder — keep in sync
+// with src/renderer/src/lib/guest-protocol.ts.
+const ALLOWED_SEND_TYPES = new Set(['token:update', 'app:info', 'app:data', 'window:isFocused'])
+const ALLOWED_LOAD_PAGES = new Set(['home', 'welcome', 'connected', 'settings'])
 
-type EventCallback = (data: any) => void
+type EventCallback = (data: unknown) => void
 const eventCallbacks: EventCallback[] = []
 
 // Embedder → Guest (push events from desktop)
@@ -23,18 +22,23 @@ contextBridge.exposeInMainWorld('applyTheme', () => {
   ipcRenderer.sendToHost('webview:event', { type: 'theme:update', data: { theme } })
 })
 
-// Expose to the Open WebUI page via contextBridge (secure, unforgeable)
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Push events: desktop → Open WebUI
   onEvent: (callback: EventCallback): void => {
     eventCallbacks.push(callback)
   },
 
-  // Request/Response: Open WebUI → desktop
-  send: (data: any): Promise<any> => {
+  send: (data: { type?: string }): Promise<unknown> => {
+    if (!data || !ALLOWED_SEND_TYPES.has(data.type ?? '')) {
+      return Promise.reject(
+        new Error(`Unsupported desktop request: ${data?.type ?? '(missing type)'}`)
+      )
+    }
     return new Promise((resolve) => {
-      const id = Math.random().toString(36).slice(2)
-      const handler = (_event: any, response: any) => {
+      const id = crypto.randomUUID()
+      const handler = (
+        _event: unknown,
+        response: { _responseId?: string; data?: unknown }
+      ): void => {
         if (response?._responseId === id) {
           ipcRenderer.removeListener('desktop:response', handler)
           resolve(response.data)
@@ -45,8 +49,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     })
   },
 
-  // Navigation: Open WebUI → desktop
   load: (page: string): void => {
+    if (!ALLOWED_LOAD_PAGES.has(page)) return
     ipcRenderer.sendToHost('webview:load', page)
   }
 })

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,8 +1,7 @@
-import { ElectronAPI } from '@electron-toolkit/preload'
-
 declare global {
   interface Window {
-    electron: ElectronAPI
-    api: unknown
+    electronAPI: unknown
   }
 }
+
+export {}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,4 @@
 import { ipcRenderer, contextBridge } from 'electron'
-import { electronAPI } from '@electron-toolkit/preload'
 
 // ─── PTY MessagePort ────────────────────────────────────
 // MessagePorts stay in the preload (cannot cross contextBridge).
@@ -57,6 +56,7 @@ const api = {
 
   // App
   getAppInfo: () => ipcRenderer.invoke('app:info'),
+  isWindowFocused: () => ipcRenderer.invoke('window:isFocused'),
   getVersion: () => ipcRenderer.invoke('get:version'),
   resetApp: () => ipcRenderer.invoke('app:reset'),
   getDefaultDataPath: () => ipcRenderer.invoke('app:defaultDataPath'),
@@ -190,14 +190,11 @@ const api = {
 
 if (process.contextIsolated) {
   try {
-    contextBridge.exposeInMainWorld('electron', electronAPI)
     contextBridge.exposeInMainWorld('electronAPI', api)
   } catch (error) {
     console.error(error)
   }
 } else {
-  // @ts-ignore
-  window.electron = electronAPI
-  // @ts-ignore
+  // @ts-expect-error non-isolated fallback
   window.electronAPI = api
 }

--- a/src/preload/spotlight-preload.ts
+++ b/src/preload/spotlight-preload.ts
@@ -38,6 +38,6 @@ if (process.contextIsolated) {
     console.error(error)
   }
 } else {
-  // @ts-ignore
+  // @ts-ignore -- window.spotlightAPI is not on the DOM lib
   window.spotlightAPI = api
 }

--- a/src/preload/voice-input-preload.ts
+++ b/src/preload/voice-input-preload.ts
@@ -43,6 +43,6 @@ if (process.contextIsolated) {
     console.error(error)
   }
 } else {
-  // @ts-ignore
+  // @ts-ignore -- window.voiceInputAPI is not on the DOM lib
   window.voiceInputAPI = api
 }

--- a/src/renderer/src/components/Versions.svelte
+++ b/src/renderer/src/components/Versions.svelte
@@ -1,9 +1,0 @@
-<script lang="ts">
-  const versions = window.electron.process.versions
-</script>
-
-<ul class="versions">
-  <li class="electron-version">Electron v{versions.electron}</li>
-  <li class="chrome-version">Chromium v{versions.chrome}</li>
-  <li class="node-version">Node v{versions.node}</li>
-</ul>

--- a/src/renderer/src/lib/components/Main/Connections.svelte
+++ b/src/renderer/src/lib/components/Main/Connections.svelte
@@ -334,8 +334,16 @@
   }
 
   // ── Webview event delivery ─────────────────────────────
-  // Single path: all events from the main process flow through here.
-  // Query events target a specific webview; everything else broadcasts.
+  // Guests are untrusted. Only Open WebUI's desktop protocol events
+  // are forwarded, and secrets stay on the local connection webview.
+  const GUEST_BROADCAST_TYPES = new Set([
+    'theme:update',
+    'models:refresh',
+    'page:reload',
+    'page:navigate'
+  ])
+  const GUEST_LOCAL_ONLY_TYPES = new Set(['connections:terminal', 'connections:openai'])
+
   const sendToWebview = (event: any, connId?: string) => {
     const container = document.querySelector('.content-webview-container')
     if (!container) return
@@ -443,8 +451,17 @@
         return
       }
 
-      // ── Everything else → broadcast to all webviews ───
-      sendToWebview(data)
+      // Terminal API keys and the local llama.cpp URL must not be
+      // delivered to remote Open WebUI origins (they run as guest JS
+      // on this machine and can fetch 127.0.0.1).
+      if (GUEST_LOCAL_ONLY_TYPES.has(data.type)) {
+        sendToWebview(data, 'local')
+        return
+      }
+
+      if (GUEST_BROADCAST_TYPES.has(data.type)) {
+        sendToWebview(data)
+      }
     })
 
     // Auto-connect to the default connection on startup so the webview

--- a/src/renderer/src/lib/components/Main/Connections/Content.svelte
+++ b/src/renderer/src/lib/components/Main/Connections/Content.svelte
@@ -3,6 +3,11 @@
   import { fade, fly } from 'svelte/transition'
   import { config, serverInfo, appState } from '../../../stores'
   import i18n from '../../../i18n'
+  import {
+    handleGuestSend,
+    isGuestLoadPage,
+    isGuestThemeEvent
+  } from '../../../guest-protocol'
   import LocalInstall from '../../Setup/LocalInstall.svelte'
   import GetStartedModal from './GetStartedModal.svelte'
   import AddConnectionModal from './AddConnectionModal.svelte'
@@ -188,20 +193,19 @@
           wv.reload()
         }
 
-        // Handle IPC messages from the webview guest (Open WebUI → desktop)
+        // Handle IPC messages from the webview guest (Open WebUI → desktop).
+        // Guests are untrusted — only allowlisted types are handled.
         wv.addEventListener('ipc-message', async (event: any) => {
           if (event.channel === 'webview:send') {
             const requestData = event.args?.[0]
             if (!requestData) return
 
-            // Handle auth token relay from webview
-            if (requestData.type === 'token:update' && requestData.token) {
-              window.electronAPI.setAuthToken?.(requestData.token)
-              return
-            }
-
             try {
-              const response = await window.electronAPI[requestData.type]?.(requestData)
+              const response = await handleGuestSend(requestData, {
+                setAuthToken: (token) => window.electronAPI.setAuthToken?.(token),
+                getAppInfo: () => window.electronAPI.getAppInfo(),
+                isWindowFocused: () => window.electronAPI.isWindowFocused()
+              })
               if (requestData._requestId) {
                 wv.send('desktop:response', {
                   _responseId: requestData._requestId,
@@ -213,10 +217,11 @@
             }
           } else if (event.channel === 'webview:load') {
             const page = event.args?.[0]
-            if (page) onSetView(page === 'home' ? 'welcome' : page)
+            if (!isGuestLoadPage(page)) return
+            onSetView(page === 'home' ? 'welcome' : page)
           } else if (event.channel === 'webview:event') {
             const payload = event.args?.[0]
-            if (!payload?.type) return
+            if (!isGuestThemeEvent(payload?.type)) return
 
             if (payload.type === 'theme:update') {
               const webuiTheme = payload.data?.theme ?? 'system'

--- a/src/renderer/src/lib/guest-protocol.ts
+++ b/src/renderer/src/lib/guest-protocol.ts
@@ -1,0 +1,90 @@
+/**
+ * Desktop ↔ Open WebUI guest protocol.
+ *
+ * The <webview> guest (local or remote Open WebUI) is untrusted. It may only
+ * send these request types; the embedder must never index window.electronAPI
+ * with a guest-supplied string.
+ *
+ * Keep GUEST_SEND_TYPES in sync with src/preload/content-preload.ts.
+ */
+
+export const GUEST_SEND_TYPES = [
+  'token:update',
+  'app:info',
+  'app:data',
+  'window:isFocused'
+] as const
+
+export type GuestSendType = (typeof GUEST_SEND_TYPES)[number]
+
+export const GUEST_LOAD_PAGES = ['home', 'welcome', 'connected', 'settings'] as const
+
+export type GuestLoadPage = (typeof GUEST_LOAD_PAGES)[number]
+
+export const GUEST_THEME_EVENTS = ['theme:update'] as const
+
+export function isGuestSendType(type: unknown): type is GuestSendType {
+  return typeof type === 'string' && (GUEST_SEND_TYPES as readonly string[]).includes(type)
+}
+
+export function isGuestLoadPage(page: unknown): page is GuestLoadPage {
+  return typeof page === 'string' && (GUEST_LOAD_PAGES as readonly string[]).includes(page)
+}
+
+export function isGuestThemeEvent(type: unknown): boolean {
+  return typeof type === 'string' && (GUEST_THEME_EVENTS as readonly string[]).includes(type)
+}
+
+export type GuestSendRequest = {
+  type?: string
+  token?: unknown
+  _requestId?: string
+}
+
+/**
+ * Handle an allowlisted guest request. Unknown types return undefined and
+ * must not be forwarded to the privileged shell API.
+ */
+export async function handleGuestSend(
+  request: GuestSendRequest,
+  api: {
+    setAuthToken: (token: string) => Promise<unknown> | unknown
+    getAppInfo: () => Promise<{
+      version?: string
+      platform?: string
+      arch?: string
+      username?: string
+    }>
+    isWindowFocused: () => Promise<{ isFocused: boolean }>
+  }
+): Promise<unknown> {
+  if (!isGuestSendType(request.type)) {
+    console.warn('[webview] ignored untrusted request type:', request.type)
+    return undefined
+  }
+
+  switch (request.type) {
+    case 'token:update':
+      if (typeof request.token === 'string' && request.token.length > 0) {
+        await api.setAuthToken(request.token)
+      }
+      return undefined
+    case 'app:info': {
+      const info = await api.getAppInfo()
+      // Do not relay OS username (or any other extra fields) to the guest.
+      return {
+        version: info?.version,
+        platform: info?.platform,
+        arch: info?.arch
+      }
+    }
+    case 'app:data':
+      // Open WebUI +layout.svelte does `if (data) appData.set(data)` but does
+      // not import the appData store (open-webui/desktop#26). A truthy value
+      // (`{}`) throws ReferenceError and the UI never mounts. `null` skips
+      // that branch. Never return config.json (API keys, envVars, paths).
+      return null
+    case 'window:isFocused':
+      return api.isWindowFocused()
+  }
+}

--- a/test/artifact-integrity.test.ts
+++ b/test/artifact-integrity.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import { createHash } from 'node:crypto'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { after, test } from 'node:test'
+import {
+  parseGithubDigest,
+  parseHfLfsSha256,
+  sha256File,
+  assertSha256,
+  fileMatchesSha256,
+  downloadAndVerifySha256
+} from '../src/main/utils/artifact-integrity.ts'
+
+const tmp = mkdtempSync(join(tmpdir(), 'owui-integrity-'))
+after(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+test('parseGithubDigest accepts sha256:hex and rejects anything else', () => {
+  const hex = 'a'.repeat(64)
+  assert.equal(parseGithubDigest(`sha256:${hex}`), hex)
+  assert.throws(() => parseGithubDigest(hex), /missing a sha256 digest/)
+  assert.throws(() => parseGithubDigest('sha256:zz'), /Invalid GitHub asset digest/)
+  assert.throws(() => parseGithubDigest('sha256:' + 'a'.repeat(63)), /Invalid/)
+})
+
+test('parseHfLfsSha256 uses lfs.sha256 only, never git oid', () => {
+  const hex = '8ccc5cd1f1b3602548715ae25a66ed73fd5dc68a210412eea643eb20eb75a135'
+  assert.equal(parseHfLfsSha256({ sha256: hex.toUpperCase() }), hex)
+  assert.throws(() => parseHfLfsSha256(undefined), /missing LFS SHA-256/)
+  assert.throws(() => parseHfLfsSha256({ oid: hex }), /missing LFS SHA-256/)
+  assert.throws(() => parseHfLfsSha256({ sha256: 'abc' }), /missing LFS SHA-256/)
+})
+
+test('sha256File / assertSha256 / fileMatchesSha256', () => {
+  const file = join(tmp, 'blob.bin')
+  writeFileSync(file, 'hello-owui')
+  const hex = createHash('sha256').update('hello-owui').digest('hex')
+  assert.equal(sha256File(file), hex)
+  assert.equal(fileMatchesSha256(file, hex), true)
+  assert.equal(fileMatchesSha256(file, 'b'.repeat(64)), false)
+  assert.doesNotThrow(() => assertSha256(file, hex))
+  assert.throws(() => assertSha256(file, 'b'.repeat(64)), /Checksum mismatch/)
+})
+
+test('downloadAndVerifySha256 writes dest only when the digest matches', async () => {
+  const payload = Buffer.from('verified-bytes')
+  const hex = createHash('sha256').update(payload).digest('hex')
+  const server = createServer((_req, res) => {
+    res.writeHead(200, { 'content-length': String(payload.length) })
+    res.end(payload)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as { port: number }
+  try {
+    const dest = join(tmp, 'ok.bin')
+    await downloadAndVerifySha256(`http://127.0.0.1:${port}/file`, dest, hex)
+    assert.equal(readFileSync(dest).toString(), 'verified-bytes')
+
+    const bad = join(tmp, 'bad.bin')
+    await assert.rejects(
+      downloadAndVerifySha256(`http://127.0.0.1:${port}/file`, bad, 'c'.repeat(64)),
+      /Checksum mismatch/
+    )
+    assert.equal(fileMatchesSha256(bad, hex), false)
+  } finally {
+    server.close()
+  }
+})

--- a/test/child-env.test.ts
+++ b/test/child-env.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  isBlockedEnvKey,
+  sanitizeChildEnv,
+  sanitizeLlamaExtraArgs
+} from '../src/main/utils/child-env.ts'
+
+test('isBlockedEnvKey is case-insensitive', () => {
+  assert.equal(isBlockedEnvKey('LD_PRELOAD'), true)
+  assert.equal(isBlockedEnvKey('ld_preload'), true)
+  assert.equal(isBlockedEnvKey('NODE_OPTIONS'), true)
+  assert.equal(isBlockedEnvKey('PYTHONHOME'), true)
+  assert.equal(isBlockedEnvKey('LD_LIBRARY_PATH'), false)
+  assert.equal(isBlockedEnvKey('PATH'), false)
+})
+
+test('sanitizeChildEnv drops blocked keys from base and extra', () => {
+  const out = sanitizeChildEnv(
+    { NODE_OPTIONS: '--require evil', KEEP: 'yes' },
+    { PATH: '/bin', LD_PRELOAD: '/tmp/x.so', KEEP_BASE: '1' }
+  )
+  assert.equal(out.PATH, '/bin')
+  assert.equal(out.KEEP, 'yes')
+  assert.equal(out.KEEP_BASE, '1')
+  assert.equal('LD_PRELOAD' in out, false)
+  assert.equal('NODE_OPTIONS' in out, false)
+})
+
+test('sanitizeLlamaExtraArgs strips host/port/models-dir including attached values', () => {
+  assert.deepEqual(
+    sanitizeLlamaExtraArgs([
+      '--n-gpu-layers',
+      '20',
+      '--host',
+      '0.0.0.0',
+      '--port=8080',
+      '--models-dir',
+      '/tmp',
+      '--ctx-size',
+      '4096'
+    ]),
+    ['--n-gpu-layers', '20', '--ctx-size', '4096']
+  )
+  assert.deepEqual(sanitizeLlamaExtraArgs('nope'), [])
+  assert.deepEqual(sanitizeLlamaExtraArgs([1, '', '--ok'] as unknown[]), ['--ok'])
+})

--- a/test/guest-protocol.test.ts
+++ b/test/guest-protocol.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  isGuestSendType,
+  isGuestLoadPage,
+  handleGuestSend,
+  GUEST_SEND_TYPES
+} from '../src/renderer/src/lib/guest-protocol.ts'
+
+const api = {
+  setAuthToken: async (token: string) => token,
+  getAppInfo: async () => ({
+    version: '0.0.20',
+    platform: 'linux',
+    arch: 'x64',
+    username: 'secret-user'
+  }),
+  isWindowFocused: async () => ({ isFocused: true })
+}
+
+test('guest send allowlist is closed', () => {
+  for (const type of GUEST_SEND_TYPES) {
+    assert.equal(isGuestSendType(type), true)
+  }
+  assert.equal(isGuestSendType('resetApp'), false)
+  assert.equal(isGuestSendType('setConfig'), false)
+  assert.equal(isGuestLoadPage('settings'), true)
+  assert.equal(isGuestLoadPage('drop-tables'), false)
+})
+
+test('handleGuestSend ignores unknown types and never returns config', async () => {
+  assert.equal(await handleGuestSend({ type: 'resetApp' }, api), undefined)
+  assert.equal(await handleGuestSend({ type: 'app:data' }, api), null)
+})
+
+test('app:info strips username', async () => {
+  const info = await handleGuestSend({ type: 'app:info' }, api)
+  assert.deepEqual(info, { version: '0.0.20', platform: 'linux', arch: 'x64' })
+})
+
+test('token:update only forwards a non-empty string', async () => {
+  const seen: string[] = []
+  const capturing = {
+    ...api,
+    setAuthToken: async (token: string) => {
+      seen.push(token)
+    }
+  }
+  await handleGuestSend({ type: 'token:update', token: 'abc' }, capturing)
+  await handleGuestSend({ type: 'token:update', token: '' }, capturing)
+  await handleGuestSend({ type: 'token:update', token: 1 }, capturing)
+  assert.deepEqual(seen, ['abc'])
+})

--- a/test/hf-paths.test.ts
+++ b/test/hf-paths.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  assertSafeRepo,
+  assertSafeFilename,
+  confinedModelPath,
+  huggingfaceDownloadUrl,
+  huggingfaceRepoApiUrl,
+  repoSlug
+} from '../src/main/utils/hf-paths.ts'
+
+test('assertSafeRepo allowlists owner/name', () => {
+  assert.equal(assertSafeRepo('ggml-org/gemma-3-1b-it-GGUF'), 'ggml-org/gemma-3-1b-it-GGUF')
+  assert.throws(() => assertSafeRepo('../etc/passwd'), /Invalid Hugging Face repository id/)
+  assert.throws(() => assertSafeRepo('no-slash'), /Invalid/)
+})
+
+test('assertSafeFilename is GGUF-only and rejects traversal', () => {
+  assert.equal(assertSafeFilename('model.gguf'), 'model.gguf')
+  assert.throws(() => assertSafeFilename('../model.gguf'), /Invalid model filename/)
+  assert.throws(() => assertSafeFilename('/tmp/model.gguf'), /Invalid model filename/)
+  assert.throws(() => assertSafeFilename('model.bin'), /Only GGUF/)
+})
+
+test('confinedModelPath stays under the cache root', () => {
+  const dest = confinedModelPath('/tmp/models', 'org/name', 'w.gguf')
+  assert.equal(dest, '/tmp/models/org--name/w.gguf')
+  assert.equal(repoSlug('org/name'), 'org--name')
+})
+
+test('Hub URLs encode the repo and request blobs=true for LFS sha256', () => {
+  const api = huggingfaceRepoApiUrl('ggml-org/gemma-3-1b-it-GGUF')
+  assert.match(api, /huggingface\.co\/api\/models\/ggml-org\/gemma-3-1b-it-GGUF\?blobs=true$/)
+  const dl = huggingfaceDownloadUrl('ggml-org/gemma-3-1b-it-GGUF', 'gemma.gguf')
+  assert.equal(
+    dl,
+    'https://huggingface.co/ggml-org/gemma-3-1b-it-GGUF/resolve/main/gemma.gguf'
+  )
+})

--- a/test/hf-paths.test.ts
+++ b/test/hf-paths.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import path from 'node:path'
 import { test } from 'node:test'
 import {
   assertSafeRepo,
@@ -24,7 +25,7 @@ test('assertSafeFilename is GGUF-only and rejects traversal', () => {
 
 test('confinedModelPath stays under the cache root', () => {
   const dest = confinedModelPath('/tmp/models', 'org/name', 'w.gguf')
-  assert.equal(dest, '/tmp/models/org--name/w.gguf')
+  assert.equal(dest, path.resolve('/tmp/models', 'org--name', 'w.gguf'))
   assert.equal(repoSlug('org/name'), 'org--name')
 })
 

--- a/test/linux-sandbox.test.ts
+++ b/test/linux-sandbox.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { linuxNeedsNoSandbox } from '../src/main/linux-sandbox.ts'
+
+test('unpackaged always needs no-sandbox', () => {
+  assert.equal(linuxNeedsNoSandbox({}, false), true)
+})
+
+test('packaged native .deb/.rpm keeps the renderer sandbox', () => {
+  assert.equal(linuxNeedsNoSandbox({}, true), false)
+})
+
+test('AppImage, snap, Flatpak, and explicit env opt in', () => {
+  assert.equal(linuxNeedsNoSandbox({ APPIMAGE: '/tmp/app.AppImage' }, true), true)
+  assert.equal(linuxNeedsNoSandbox({ SNAP: '/snap/owui' }, true), true)
+  assert.equal(linuxNeedsNoSandbox({ FLATPAK_ID: 'com.openwebui.desktop' }, true), true)
+  assert.equal(linuxNeedsNoSandbox({ ELECTRON_DISABLE_SANDBOX: '1' }, true), true)
+})

--- a/test/llama-release.test.ts
+++ b/test/llama-release.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  pickLatestLlamaCppRelease,
+  releaseHasLlamaBinaries,
+  type GithubRelease
+} from '../src/main/utils/llama-release.ts'
+
+const hashedBin: GithubRelease = {
+  tag_name: 'b1234',
+  assets: [
+    {
+      name: 'llama-b1234-bin-ubuntu-x64.tar.gz',
+      browser_download_url: 'https://example.invalid/a',
+      digest: 'sha256:' + 'a'.repeat(64)
+    }
+  ]
+}
+
+test('releaseHasLlamaBinaries requires hashed *-bin-* assets and skips drafts', () => {
+  assert.equal(releaseHasLlamaBinaries(hashedBin), true)
+  assert.equal(releaseHasLlamaBinaries({ tag_name: 'v0.4.0', assets: [] }), false)
+  assert.equal(
+    releaseHasLlamaBinaries({
+      tag_name: 'b1',
+      assets: [{ name: 'llama-b1-bin-x64.tar.gz', browser_download_url: 'x' }]
+    }),
+    false
+  )
+  assert.equal(releaseHasLlamaBinaries({ ...hashedBin, draft: true }), false)
+})
+
+test('pickLatestLlamaCppRelease skips a latest tag with no binaries', () => {
+  const picked = pickLatestLlamaCppRelease([
+    { tag_name: 'v0.4.0', assets: [] },
+    hashedBin
+  ])
+  assert.equal(picked.tag_name, 'b1234')
+  assert.throws(() => pickLatestLlamaCppRelease([{ tag_name: 'v0.4.0' }]), /No llama.cpp/)
+})

--- a/test/safe-open.test.ts
+++ b/test/safe-open.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  isAllowedExternalUrl,
+  isPathInside,
+  normalizeOpenUrl
+} from '../src/main/safe-open.ts'
+
+test('isAllowedExternalUrl allows http(s)/mailto and rejects the rest', () => {
+  assert.equal(isAllowedExternalUrl('https://example.com/a'), true)
+  assert.equal(isAllowedExternalUrl('http://127.0.0.1:8080'), true)
+  assert.equal(isAllowedExternalUrl('mailto:a@b.c'), true)
+  assert.equal(isAllowedExternalUrl('file:///etc/passwd'), false)
+  assert.equal(isAllowedExternalUrl('javascript:alert(1)'), false)
+  assert.equal(isAllowedExternalUrl('not a url'), false)
+})
+
+test('normalizeOpenUrl rewrites 0.0.0.0 to localhost', () => {
+  assert.equal(normalizeOpenUrl('http://0.0.0.0:8080/ui'), 'http://localhost:8080/ui')
+  assert.equal(normalizeOpenUrl('https://example.com'), 'https://example.com')
+})
+
+test('isPathInside confines targets to the given roots', () => {
+  assert.equal(isPathInside('/data/models/a.gguf', ['/data/models']), true)
+  assert.equal(isPathInside('/data/models', ['/data/models']), true)
+  assert.equal(isPathInside('/data/models-evil/a', ['/data/models']), false)
+  assert.equal(isPathInside('/etc/passwd', ['/data/models']), false)
+})

--- a/test/safe-pty.test.ts
+++ b/test/safe-pty.test.ts
@@ -41,12 +41,37 @@ test('safePtyWrite swallows throws after exit', () => {
   assert.equal(safePtyWrite(fake, 'x'), false)
 })
 
+function spawnExitingPty() {
+  // cmd.exe is the authentic Windows conpty path (#255). Linux/mac use sh.
+  if (process.platform === 'win32') {
+    return pty.spawn(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', 'exit 0'], {
+      name: 'xterm',
+      cols: 80,
+      rows: 24
+    })
+  }
+  return pty.spawn('sh', ['-c', 'exit 0'], { name: 'xterm', cols: 80, rows: 24 })
+}
+
 test('live node-pty: resize after exit does not throw out of the helper', async () => {
-  const child = pty.spawn('sh', ['-c', 'exit 0'], { name: 'xterm', cols: 80, rows: 24 })
-  await new Promise<void>((resolve) => {
-    child.onExit(() => resolve())
-  })
-  assert.doesNotThrow(() => safePtyResize(child, 100, 30))
-  assert.equal(safePtyResize(child, 100, 30), false)
-  assert.doesNotThrow(() => safePtyWrite(child, 'x'))
+  const child = spawnExitingPty()
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('PTY did not exit')), 10_000)
+      child.onExit(() => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+    assert.doesNotThrow(() => safePtyResize(child, 100, 30))
+    assert.equal(safePtyResize(child, 100, 30), false)
+    assert.doesNotThrow(() => safePtyWrite(child, 'x'))
+  } finally {
+    try {
+      child.kill()
+    } catch {
+      // Windows conpty can throw here after exit; the agent must still be torn down
+      // so node:test can leave the event loop.
+    }
+  }
 })

--- a/test/safe-pty.test.ts
+++ b/test/safe-pty.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import pty from 'node-pty'
+import { safePtyResize, safePtyWrite } from '../src/main/utils/safe-pty.ts'
+
+test('safePtyResize swallows the Windows "already exited" error', () => {
+  const fake = {
+    resize: () => {
+      throw new Error('Cannot resize a pty that has already exited')
+    }
+  }
+  assert.equal(safePtyResize(fake, 80, 24), false)
+})
+
+test('safePtyResize swallows Linux ioctl EBADF after exit', () => {
+  const fake = {
+    resize: () => {
+      throw new Error('ioctl(2) failed, EBADF')
+    }
+  }
+  assert.equal(safePtyResize(fake, 120, 40), false)
+})
+
+test('safePtyResize returns true when the PTY is alive', () => {
+  const calls: [number, number][] = []
+  const fake = {
+    resize: (cols: number, rows: number) => {
+      calls.push([cols, rows])
+    }
+  }
+  assert.equal(safePtyResize(fake, 80, 24), true)
+  assert.deepEqual(calls, [[80, 24]])
+})
+
+test('safePtyWrite swallows throws after exit', () => {
+  const fake = {
+    write: () => {
+      throw new Error('Cannot write to a pty that has already exited')
+    }
+  }
+  assert.equal(safePtyWrite(fake, 'x'), false)
+})
+
+test('live node-pty: resize after exit does not throw out of the helper', async () => {
+  const child = pty.spawn('sh', ['-c', 'exit 0'], { name: 'xterm', cols: 80, rows: 24 })
+  await new Promise<void>((resolve) => {
+    child.onExit(() => resolve())
+  })
+  assert.doesNotThrow(() => safePtyResize(child, 100, 30))
+  assert.equal(safePtyResize(child, 100, 30), false)
+  assert.doesNotThrow(() => safePtyWrite(child, 'x'))
+})


### PR DESCRIPTION
## Description

Guest Open WebUI pages (including remote connections) could invoke the full privileged desktop API via `window.electronAPI[requestData.type]`. Remote webviews also received Open Terminal API keys. TLS verification was disabled on every Chromium session. Python, llama.cpp, and Hugging Face GGUF downloads were not checksummed. Linux always launched with `--no-sandbox`. Packaged Electron fuses were left at insecure defaults. macOS/Windows releases published unsigned fallbacks on codesign failure.

This PR allowlists guest IPC, scopes TLS exceptions to user-added connection origins, verifies downloaded artifacts, sandboxes shell windows, pins Electron to 39.8.10 (GHSA-h7rp-cf8h-j98x), keeps Cloudflare Access / SSO login inside the app, and fails closed on unsigned releases.

Production shell windows load `app://renderer/…` instead of `file://`. Dev (`npm run dev`) is unchanged.

**Overlaps (maintainers may want to close or rebase):**
- #253 (webview message handling) — this allowlists guest `send()` and does not index `electronAPI` with guest strings
- #218 / #175 (OAuth popups in Electron) — Access/OIDC popups share the guest session; chat links still open externally (#165)
- #217 (dedicated auth window)

Fork-only docs (`CLAUDE.md`, `DECISIONS.md`, develop-branch model) are **not** in this PR.

### Security
- Guest `send()` allowlist: `token:update`, `app:info`, `app:data`, `window:isFocused`
- `will-attach-webview` forces `sandbox` / `contextIsolation` / no Node
- Terminal/OpenAI events only to the local-connection webview
- TLS default-verify; exceptions only for configured connection origins + localhost
- `openExternal` is `http:`/`https:`/`mailto:` only
- HF paths confined; GGUF SHA-256 from Hub LFS (`?blobs=true`)
- Python / llama.cpp downloads hashed; llama.cpp “latest” picks a release that actually has binaries
- Child env blocklist; llama `--host`/`--port`/`--models-dir` always from the desktop
- Linux `--no-sandbox` only for AppImage/snap/Flatpak/unpackaged/`ELECTRON_DISABLE_SANDBOX=1`
- Electron fuses at pack time; shell `sandbox: true`; drop `@electron-toolkit/preload` `window.electron`

### Fixes
- Access/SSO stays in the webview (session cookies land; UI loads after callback)
- Tray Quit actually exits
- Guest no longer crashes on `app:data` (`null` instead of `{}` — Open WebUI `+layout.svelte` does not import `appData`)
- Quit waits for child processes

### Infrastructure
- `npm test` (23 `node:test` cases on the security helpers)
- CI: typecheck, tests, eslint on `src/main` + preload

## Related Issues

Related to #175, #165. Does not close those if #218 is the intended path for OAuth host allowlisting.

## Verification

```
npm test          # 23 pass
npm run lint:main # exit 0
npx tsc --noEmit -p tsconfig.node.json --composite false
```

---

## Contributor License Agreement

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/desktop/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.